### PR TITLE
AsyncImageView: request a new image if bounds are updated.

### DIFF
--- a/AsyncImageView/AsyncImageView.swift
+++ b/AsyncImageView/AsyncImageView.swift
@@ -91,6 +91,12 @@ public final class AsyncImageView<
 		}
 	}
 
+	public override var bounds: CGRect {
+		didSet {
+			self.requestNewImageIfReady()
+		}
+	}
+
 	public var data: ImageViewData? {
 		didSet {
 			self.requestNewImageIfReady()

--- a/AsyncImageViewTests/AsyncImageViewSpec.swift
+++ b/AsyncImageViewTests/AsyncImageViewSpec.swift
@@ -79,6 +79,15 @@ class AsyncImageViewSpec: QuickSpec {
 						verifyView()
 					}
 
+					it("updates image when updating bounds") {
+						view.frame.size = CGSize(width: 10, height: 10)
+						view.data = .C
+
+						view.bounds.size = CGSize(width: 15, height: 15)
+
+						verifyView()
+					}
+
 					it("resets image when updating data") {
 						view.frame.size = CGSize(width: 10, height: 10)
 						view.data = .C


### PR DESCRIPTION
This fixes a bug that made `AsyncImageView` not request new images when AutoLayout changes the size.
