### PR TITLE
Add tests for `drawingRectForRenderingWithAspectFit`

### DIFF
--- a/AsyncImageViewTests/ImageInflaterRendererSpec.swift
+++ b/AsyncImageViewTests/ImageInflaterRendererSpec.swift
@@ -13,8 +13,167 @@ import RandomKit
 import AsyncImageView
 
 class ImageInflaterRendererSpec: QuickSpec {
-	override func spec() {
-		describe("ImageInflaterRenderer") {
+    override func spec() {
+        describe("ImageInflaterRenderer") {
+            context("Aspect Fit") {
+                it("returns identity frame if sizes match") {
+                    let size = CGSize.random()
+                    let result = InflaterSizeCalculator.drawingRectForRenderingWithAspectFit(
+                        imageSize: size,
+                        inSize: size
+                    )
+                    
+                    expect(result) == CGRect(origin: CGPoint.zero, size: size)
+                }
+                
+                it("reduces size if aspect ratio matches, but canvas is smaller") {
+                    let imageSize = CGSize.random()
+                    let canvasSize = CGSize(width: imageSize.width * 0.4, height: imageSize.height * 0.4)
+                    
+                    let result = InflaterSizeCalculator.drawingRectForRenderingWithAspectFit(
+                        imageSize: imageSize,
+                        inSize: canvasSize
+                    )
+                    
+                    expect(result) == CGRect(origin: CGPoint.zero, size: canvasSize)
+                }
+                
+                it("scales up size if aspect ratio matches, but canvas is bigger") {
+                    let imageSize = CGSize.random()
+                    let canvasSize = CGSize(width: imageSize.width * 2, height: imageSize.height * 2)
+                    
+                    let result = InflaterSizeCalculator.drawingRectForRenderingWithAspectFit(
+                        imageSize: imageSize,
+                        inSize: canvasSize
+                    )
+                    
+                    expect(result) == CGRect(origin: CGPoint.zero, size: canvasSize)
+                }
+                
+                it("scales and centers image vertically if height matches, but canvas width is smaller") {
+                    let imageSize = CGSize(width: 1242, height: 240)
+                    let canvasSize = CGSize(width: 750, height: 240)
+                    
+                    let result = InflaterSizeCalculator.drawingRectForRenderingWithAspectFit(
+                        imageSize: imageSize,
+                        inSize: canvasSize
+                    )
+                    
+                    let expectedHeight = canvasSize.height * (canvasSize.width / imageSize.width) // preserve aspect ratio
+                    
+                    expect(result.origin) == CGPoint(x: 0, y: (expectedHeight - canvasSize.height) / -2.0)
+                    expect(result.size.width).to(beCloseTo(canvasSize.width))
+                    expect(result.size.height).to(beCloseTo(expectedHeight))                }
+                
+                it("centers horizontally if height matches, but canvas width is bigger") {
+                    let imageSize = CGSize(width: 1242, height: 240)
+                    let canvasSize = CGSize(width: 1334, height: 240)
+                    
+                    let result = InflaterSizeCalculator.drawingRectForRenderingWithAspectFit(
+                        imageSize: imageSize,
+                        inSize: canvasSize
+                    )
+                    
+                    expect(result.origin) == CGPoint(x: (imageSize.width - canvasSize.width) / -2.0, y: 0)
+                    expect(result.size) == imageSize
+                }
+                
+                it("scales and centers image horizontally if width matches, but canvas height is smaller") {
+                    let imageSize = CGSize(width: 1242, height: 240)
+                    let canvasSize = CGSize(width: 1242, height: 100)
+                    
+                    let result = InflaterSizeCalculator.drawingRectForRenderingWithAspectFit(
+                        imageSize: imageSize,
+                        inSize: canvasSize
+                    )
+                    
+                    let expectedWidth = canvasSize.width * (canvasSize.height / imageSize.height) // preserve aspect ratio
+                    
+                    expect(result.origin) == CGPoint(x: (expectedWidth - canvasSize.width) / -2.0, y: 0)
+                    expect(result.size.width).to(beCloseTo(expectedWidth))
+                    expect(result.size.height).to(beCloseTo(canvasSize.height))
+                }
+                
+                it("centers vertically if width matches, but canvas height is bigger") {
+                    let imageSize = CGSize(width: 1242, height: 240)
+                    let canvasSize = CGSize(width: 1242, height: 300)
+                    
+                    let result = InflaterSizeCalculator.drawingRectForRenderingWithAspectFit(
+                        imageSize: imageSize,
+                        inSize: canvasSize
+                    )
+                    
+                    expect(result.origin) == CGPoint(x: 0, y: (imageSize.height - canvasSize.height) / -2.0)
+                    expect(result.size) == imageSize
+                }
+                
+                context("aspect ratio and image size are different") {
+                    context("image size is smaller") {
+                        it("image aspect ratio is smaller") {
+                            let imageSize = CGSize(width: 30, height: 40)
+                            let canvasSize = CGSize(width: 50, height: 60)
+                            
+                            let result = InflaterSizeCalculator.drawingRectForRenderingWithAspectFit(
+                                imageSize: imageSize,
+                                inSize: canvasSize
+                            )
+                            
+                            expect(result.origin.x).to(beCloseTo(2.5))
+                            expect(result.origin.y).to(beCloseTo(0))
+                            expect(result.size.width).to(beCloseTo(45))
+                            expect(result.size.height).to(beCloseTo(60))
+                        }
+                        
+                        it("image aspect ratio is bigger") {
+                            let imageSize = CGSize(width: 50, height: 60)
+                            let canvasSize = CGSize(width: 60, height: 80)
+                            
+                            let result = InflaterSizeCalculator.drawingRectForRenderingWithAspectFit(
+                                imageSize: imageSize,
+                                inSize: canvasSize
+                            )
+                            
+                            expect(result.origin.x).to(beCloseTo(0))
+                            expect(result.origin.y).to(beCloseTo(4))
+                            expect(result.size.width).to(beCloseTo(60))
+                            expect(result.size.height).to(beCloseTo(72))
+                        }
+                    }
+                    
+                    context("image size is bigger") {
+                        it("image aspect ratio is smaller") {
+                            let imageSize = CGSize(width: 60, height: 80)
+                            let canvasSize = CGSize(width: 50, height: 60)
+                            
+                            let result = InflaterSizeCalculator.drawingRectForRenderingWithAspectFit(
+                                imageSize: imageSize,
+                                inSize: canvasSize
+                            )
+                            
+                            expect(result.origin.x).to(beCloseTo(2.5))
+                            expect(result.origin.y).to(beCloseTo(0))
+                            expect(result.size.width).to(beCloseTo(45))
+                            expect(result.size.height).to(beCloseTo(60))
+                        }
+                        
+                        it("image aspect ratio is bigger") {
+                            let imageSize = CGSize(width: 100, height: 120)
+                            let canvasSize = CGSize(width: 60, height: 80)
+                            
+                            let result = InflaterSizeCalculator.drawingRectForRenderingWithAspectFit(
+                                imageSize: imageSize,
+                                inSize: canvasSize
+                            )
+                            
+                            expect(result.origin.x).to(beCloseTo(0))
+                            expect(result.origin.y).to(beCloseTo(4))
+                            expect(result.size.width).to(beCloseTo(60))
+                            expect(result.size.height).to(beCloseTo(72))
+                        }
+                    }
+                }
+            }
+            
             context("Aspect Fill") {
                 it("returns identity frame if sizes match") {
                     let size = CGSize.random()
@@ -178,5 +337,5 @@ class ImageInflaterRendererSpec: QuickSpec {
                 }
             }
         }
-	}
+    }
 }


### PR DESCRIPTION
This PR adds tests to verify that the Aspect Fit inflater is indeed sizing images correctly, given the current canvas.