### PR TITLE
AsyncImageLoader: don't allow failed renderers to stop placeholder from showing

### DIFF
--- a/AsyncImageView/AsyncImageLoader.swift
+++ b/AsyncImageView/AsyncImageLoader.swift
@@ -48,7 +48,11 @@ Renderer.RenderResult == PlaceholderRenderer.RenderResult {
                     if let placeholderRenderer = placeholderRenderer {
                         return placeholderRenderer
                             .renderImageWithData(data)
-                            .take(untilReplacement: renderer.renderImageWithData(data))
+                            .take(
+                                untilReplacement: renderer.renderImageWithData(data)
+                                    // Don't allow a finishing signal to cancel replacement without a value (like if it failed)
+                                    .concat(.never)
+                            )
                     } else {
                         return renderer.renderImageWithData(data)
                     }


### PR DESCRIPTION
This was a long standing issue with placeholders.