### PR TITLE
Preserve cache hit metadata after image transforms

### DIFF
--- a/AsyncImageView/Renderers/Renderer.swift
+++ b/AsyncImageView/Renderers/Renderer.swift
@@ -20,7 +20,14 @@ public protocol RenderResultType {
 	var cacheHit: Bool { get }
 }
 
-public struct ImageResult: RenderResultType {
+/// Render results that can produce a new instance by replacing their underlying image
+/// should conform to this protocol so that decorators that transform images can
+/// preserve metadata such as `cacheHit`.
+public protocol ImageReplacingRenderResultType: RenderResultType {
+	func replacingImage(_ image: UIImage) -> Self
+}
+
+public struct ImageResult: RenderResultType, ImageReplacingRenderResultType {
 	public let image: UIImage
 	public let cacheHit: Bool
 
@@ -30,7 +37,7 @@ public struct ImageResult: RenderResultType {
 	}
 }
 
-extension UIImage: RenderResultType {
+extension UIImage: RenderResultType, ImageReplacingRenderResultType {
 	public var image: UIImage {
 		return self
 	}
@@ -38,6 +45,10 @@ extension UIImage: RenderResultType {
 	public var cacheHit: Bool {
 		// A raw UIImage created by a `RendererType` is implicitly not cached.
 		return false
+	}
+
+	public func replacingImage(_ image: UIImage) -> UIImage {
+		return image
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated protocol for render results that can recreate themselves with a new image so decorators can preserve metadata
- update the image inflater and simple image processing renderers to keep cache-hit information alive when they transform images
- add regression tests that ensure cache-hit flags survive both inflation and `mapImage` processing

## Testing
- `swift test` *(fails: unable to clone https://github.com/ReactiveCocoa/ReactiveSwift.git – HTTP 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b7c6df29c8320a87bd8fd029caacf)