### PR TITLE
Add test target to Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,13 +8,24 @@ let package = Package(
         .library(name: "AsyncImageView", targets: ["AsyncImageView"]),
     ],
     dependencies: [
-				.package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "7.1.0")
+        .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "7.1.0"),
+        .package(url: "https://github.com/Quick/Quick.git", from: "7.4.0"),
+        .package(url: "https://github.com/Quick/Nimble.git", from: "12.2.0"),
     ],
     targets: [
         .target(
             name: "AsyncImageView",
             dependencies: ["ReactiveSwift"],
             path: "AsyncImageView"
+        ),
+        .testTarget(
+            name: "AsyncImageViewTests",
+            dependencies: [
+                "AsyncImageView",
+                "Quick",
+                "Nimble",
+            ],
+            path: "AsyncImageViewTests"
         ),
     ],
     swiftLanguageVersions: [.v5]


### PR DESCRIPTION
## Summary
- add Quick and Nimble as test-only dependencies in the Swift package manifest
- define the `AsyncImageViewTests` test target that depends on the library and new testing frameworks

## Testing
- Not run (UIKit-based packages are unavailable in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ba6d202148320abdec44ebd8da6e6)