### PR TITLE
Fix QuickSpec overrides and imports

### DIFF
--- a/AsyncImageViewTests/AsyncImageViewSpec.swift
+++ b/AsyncImageViewTests/AsyncImageViewSpec.swift
@@ -8,13 +8,15 @@
 
 import Quick
 import Nimble
+import UIKit
+import XCTest
 
 import ReactiveSwift
 
 import AsyncImageView
 
 class AsyncImageViewSpec: QuickSpec {
-	override func spec() {
+	override class func spec() {
 		describe("AsyncImageView") {
             // To ensure that updating UI takes one extra cycle
             // and we can verify image is reset before that

--- a/AsyncImageViewTests/CachingSpec.swift
+++ b/AsyncImageViewTests/CachingSpec.swift
@@ -8,6 +8,8 @@
 
 import Quick
 import Nimble
+import Foundation
+import CoreGraphics
 
 import AsyncImageView
 
@@ -62,7 +64,7 @@ private func testCache<T: CacheType>(
 }
 
 class InMemoryCacheSpec: QuickSpec {
-	override func spec() {
+	override class func spec() {
 		describe("InMemoryCache") {
 			testCache(
 				cacheCreator: { InMemoryCache<String, String>(cacheName: "test") },
@@ -74,7 +76,7 @@ class InMemoryCacheSpec: QuickSpec {
 }
 
 class DiskCacheSpec: QuickSpec {
-	override func spec() {
+	override class func spec() {
 		describe("DiskCache") {
 			let directoryCreator = {
 				return URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
@@ -109,7 +111,7 @@ class DiskCacheSpec: QuickSpec {
 }
 
 class RenderDataTypeCacheSubdirectorySpec: QuickSpec {
-	override func spec() {
+	override class func spec() {
 		it("works with integer sizes") {
 			expect(subdirectoryForSize(CGSize(width: 15.0, height: 10.0))) == "15.00x10.00"
 		}

--- a/AsyncImageViewTests/ImageInflaterRendererSpec.swift
+++ b/AsyncImageViewTests/ImageInflaterRendererSpec.swift
@@ -8,11 +8,12 @@
 
 import Quick
 import Nimble
+import CoreGraphics
 
 import AsyncImageView
 
 class ImageInflaterRendererSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("ImageInflaterRenderer") {
             context("Aspect Fit") {
                 it("returns identity frame if sizes match") {

--- a/AsyncImageViewTests/MulticastedRendererSpec.swift
+++ b/AsyncImageViewTests/MulticastedRendererSpec.swift
@@ -8,13 +8,16 @@
 
 import Quick
 import Nimble
+import UIKit
+import Foundation
+import XCTest
 
 import ReactiveSwift
 
 import AsyncImageView
 
 class MulticastedRendererSpec: QuickSpec {
-	override func spec() {
+	override class func spec() {
 		describe("MulticastedRenderer") {
 			let data: TestData = .a
 			let size = CGSize(width: 1, height: 1)

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,75 @@
 {
   "pins" : [
     {
+      "identity" : "cwlcatchexception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlCatchException.git",
+      "state" : {
+        "revision" : "07b2ba21d361c223e25e3c1e924288742923f08c",
+        "version" : "2.2.1"
+      }
+    },
+    {
+      "identity" : "cwlpreconditiontesting",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+      "state" : {
+        "revision" : "0139c665ebb45e6a9fbdb68aabfd7c39f3fe0071",
+        "version" : "2.2.2"
+      }
+    },
+    {
+      "identity" : "nimble",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Quick/Nimble.git",
+      "state" : {
+        "revision" : "edaedc1ec86f14ac6e2ca495b94f0ff7150d98d0",
+        "version" : "12.3.0"
+      }
+    },
+    {
+      "identity" : "quick",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Quick/Quick.git",
+      "state" : {
+        "revision" : "1163a1b1b114a657c7432b63dd1f92ce99fe11a6",
+        "version" : "7.6.2"
+      }
+    },
+    {
       "identity" : "reactiveswift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ReactiveCocoa/ReactiveSwift.git",
       "state" : {
         "revision" : "40c465af19b993344e84355c00669ba2022ca3cd",
         "version" : "7.1.1"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "cdd0ef3755280949551dc26dee5de9ddeda89f54",
+        "version" : "1.6.2"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
       }
     }
   ],


### PR DESCRIPTION
## Summary
- switch every QuickSpec subclass in the test target to override `class func spec()` to match Quick 7.6.2’s API
- add the UIKit/Foundation/CoreGraphics/XCTest imports required for types like `UIImage`, `CGSize`, and `XCTFail`
- refresh `Package.resolved` after resolving dependencies

## Testing
- `swift test` *(fails on Linux because the AsyncImageView target requires Apple’s Combine framework)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bb2685fb48320ba81298ea905d1ae)