### PR TITLE
Fix cache specs to compile with Quick

### DIFF
--- a/AsyncImageViewTests/CachingSpec.swift
+++ b/AsyncImageViewTests/CachingSpec.swift
@@ -13,64 +13,50 @@ import CoreGraphics
 
 import AsyncImageView
 
-private func testCache<T: CacheType>(
-	cacheCreator: @escaping () -> T,
-	keyCreator: @escaping () -> T.Key,
-	valueCreator: @escaping () -> T.Value
-)
-	where T.Value: Equatable
-{
-	var cache: T!
-
-	beforeEach {
-		cache = cacheCreator()
-	}
-
-	it("returns nil when not cached") {
-		expect(cache.valueForKey(keyCreator())).to(beNil())
-	}
-
-	it("recovers value after saving it") {
-		let key = keyCreator()
-		let value = valueCreator()
-
-		cache.setValue(value, forKey: key)
-
-		expect(cache.valueForKey(key)) == value
-	}
-
-	it("values don't override") {
-		let key1 = keyCreator()
-		let key2 = keyCreator()
-		let value1 = valueCreator()
-		let value2 = valueCreator()
-
-		cache.setValue(value1, forKey: key1)
-		cache.setValue(value2, forKey: key2)
-
-		expect(cache.valueForKey(key1)) == value1
-		expect(cache.valueForKey(key2)) == value2
-	}
-
-	it("can remove a value") {
-		let key = keyCreator()
-		let value = valueCreator()
-
-		cache.setValue(value, forKey: key)
-		cache.setValue(nil, forKey: key)
-
-		expect(cache.valueForKey(key)).to(beNil())
-	}
-}
-
 class InMemoryCacheSpec: QuickSpec {
 	override class func spec() {
 		describe("InMemoryCache") {
-			testCache(
-				cacheCreator: { InMemoryCache<String, String>(cacheName: "test") },
-				keyCreator: String.randomReadableString,
-				valueCreator: String.randomReadableString
-			)
+			var cache: InMemoryCache<String, String>!
+
+			beforeEach {
+				cache = InMemoryCache(cacheName: "test")
+			}
+
+			it("returns nil when not cached") {
+				expect(cache.valueForKey(UUID().uuidString)).to(beNil())
+			}
+
+			it("recovers value after saving it") {
+				let key = UUID().uuidString
+				let value = String.randomReadableString()
+
+				cache.setValue(value, forKey: key)
+
+				expect(cache.valueForKey(key)) == value
+			}
+
+			it("values don't override") {
+				let key1 = UUID().uuidString
+				let key2 = UUID().uuidString
+				let value1 = String.randomReadableString()
+				let value2 = String.randomReadableString()
+
+				cache.setValue(value1, forKey: key1)
+				cache.setValue(value2, forKey: key2)
+
+				expect(cache.valueForKey(key1)) == value1
+				expect(cache.valueForKey(key2)) == value2
+			}
+
+			it("can remove a value") {
+				let key = UUID().uuidString
+				let value = String.randomReadableString()
+
+				cache.setValue(value, forKey: key)
+				cache.setValue(nil, forKey: key)
+
+				expect(cache.valueForKey(key)).to(beNil())
+			}
 		}
 	}
 }
@@ -83,13 +69,47 @@ class DiskCacheSpec: QuickSpec {
 					.appendingPathComponent(ProcessInfo.processInfo.globallyUniqueString, isDirectory: true)
 			}
 
-			testCache(
-				cacheCreator: { () -> DiskCache<String, String> in
-					return DiskCache(rootDirectory: directoryCreator())
-				},
-				keyCreator: String.randomReadableString,
-				valueCreator: String.randomReadableString
-			)
+			var cache: DiskCache<String, String>!
+
+			beforeEach {
+				cache = DiskCache(rootDirectory: directoryCreator())
+			}
+
+			it("returns nil when not cached") {
+				expect(cache.valueForKey(UUID().uuidString)).to(beNil())
+			}
+
+			it("recovers value after saving it") {
+				let key = UUID().uuidString
+				let value = String.randomReadableString()
+
+				cache.setValue(value, forKey: key)
+
+				expect(cache.valueForKey(key)) == value
+			}
+
+			it("values don't override") {
+				let key1 = UUID().uuidString
+				let key2 = UUID().uuidString
+				let value1 = String.randomReadableString()
+				let value2 = String.randomReadableString()
+
+				cache.setValue(value1, forKey: key1)
+				cache.setValue(value2, forKey: key2)
+
+				expect(cache.valueForKey(key1)) == value1
+				expect(cache.valueForKey(key2)) == value2
+			}
+
+			it("can remove a value") {
+				let key = UUID().uuidString
+				let value = String.randomReadableString()
+
+				cache.setValue(value, forKey: key)
+				cache.setValue(nil, forKey: key)
+
+				expect(cache.valueForKey(key)).to(beNil())
+			}
 
 			it("saves files in subdirectory") {
 				func readFile(_ url: URL) -> String? {


### PR DESCRIPTION
## Summary
- inline the cache behavior specs inside their respective `QuickSpec` classes so the Quick DSL is available when compiling

## Testing
- `swift test` *(fails: Combine is unavailable on Linux in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bb5ae6b2c8320b9952183021160ba)