### PR TITLE
Add warnings-as-errors flag to CI build

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,4 +25,5 @@ jobs:
           scheme: AsyncImageView
           platform: iOS
           action: test
+          warnings-as-errors: true
           verbosity: xcbeautify


### PR DESCRIPTION
## Summary
- ensure the GitHub Actions workflow runs `xcodebuild` with warnings treated as errors

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bc11db11c832096728b8cd2278beb)