### PR TITLE
Fix locale-dependent cache subdirectory formatting

### DIFF
--- a/AsyncImageView/Renderers/CacheRenderer.swift
+++ b/AsyncImageView/Renderers/CacheRenderer.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Foundation
 
 import ReactiveSwift
 
@@ -67,8 +68,20 @@ extension RenderDataType where Self: DataFileType {
 	}
 }
 
+private let renderDataSubdirectoryLocale = Locale(identifier: "en_US_POSIX")
+private let renderDataSubdirectoryFormat = "%.2fx%.2f"
+
+internal func subdirectoryForSize(_ size: CGSize, locale: Locale) -> String {
+	return String(
+        format: renderDataSubdirectoryFormat,
+        locale: locale,
+        size.width,
+        size.height
+    )
+}
+
 public func subdirectoryForSize(_ size: CGSize) -> String {
-	return String(format: "%.2fx%.2f", size.width, size.height)
+    return subdirectoryForSize(size, locale: renderDataSubdirectoryLocale)
 }
 
 private enum CacheRendererError: Error {
@@ -90,4 +103,3 @@ private extension UIImage {
 		)
 	}
 }
-

--- a/AsyncImageViewTests/CachingSpec.swift
+++ b/AsyncImageViewTests/CachingSpec.swift
@@ -11,7 +11,7 @@ import Nimble
 import Foundation
 import CoreGraphics
 
-import AsyncImageView
+@testable import AsyncImageView
 
 class InMemoryCacheSpec: QuickSpec {
 	override class func spec() {
@@ -137,6 +137,12 @@ class RenderDataTypeCacheSubdirectorySpec: QuickSpec {
 		}
 
 		it("has limited precision") {
+			expect(subdirectoryForSize(CGSize(width: 15.1245, height: 10.6123))) == "15.12x10.61"
+		}
+
+		it("does not depend on the current locale's decimal separator") {
+			let locale = Locale(identifier: "fr_FR")
+			expect(subdirectoryForSize(CGSize(width: 15.1245, height: 10.6123), locale: locale)) == "15,12x10,61"
 			expect(subdirectoryForSize(CGSize(width: 15.1245, height: 10.6123))) == "15.12x10.61"
 		}
 	}


### PR DESCRIPTION
## Summary
- ensure the cache subdirectory that backs disk caching is always formatted with an `en_US_POSIX` locale so decimal separators never switch to commas on some devices
- expose an internal helper so locale-sensitive formatting can be verified and add a Quick spec that demonstrates the regression scenario

## Testing
- `swift test` *(fails on Linux because Apple-only frameworks such as Combine/UIKit are unavailable in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bca2b53e083208d6c23006fa47aa8)