### PR TITLE
[Fix] Fall back when bitmap context creation fails

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Run test suite
         uses: mxcl/xcodebuild@v3
         with:
-          xcode: '26.1'
+          xcode: '26.5'
           scheme: AsyncImageView
           platform: iOS
           action: test

--- a/AsyncImageView/Renderers/ImageInflaterRenderer.swift
+++ b/AsyncImageView/Renderers/ImageInflaterRenderer.swift
@@ -70,6 +70,14 @@ public enum ImageInflaterRendererContentMode {
 }
 
 extension UIImage {
+	internal typealias BitmapContextFactory = (
+		_ width: Int,
+		_ height: Int,
+		_ bytesPerRow: Int,
+		_ colorSpace: CGColorSpace,
+		_ bitmapInfo: UInt32
+	) -> CGContext?
+
     internal func inflate(
         withSize size: CGSize,
         scale: CGFloat,
@@ -92,6 +100,17 @@ extension UIImage {
 		scale: CGFloat,
 		opaque: Bool,
 		contentMode: ImageInflaterRendererContentMode,
+		bitmapContextFactory: BitmapContextFactory = { width, height, bytesPerRow, colorSpace, bitmapInfo in
+			CGContext(
+				data: nil,
+				width: width,
+				height: height,
+				bitsPerComponent: 8,
+				bytesPerRow: bytesPerRow,
+				space: colorSpace,
+				bitmapInfo: bitmapInfo
+			)
+		},
 		renderingBlock: (_ image: UIImage, _ context: CGContext, _ contextSize: CGSize, _ imageDrawing: () -> Void) -> Void)
 		-> UIImage {
 		precondition(size.width > 0 && size.height > 0, "Invalid size: \(size.width)x\(size.height)")
@@ -105,8 +124,14 @@ extension UIImage {
 		let imageWidth = Int(contextSize.width)
 		let imageHeight = Int(contextSize.height)
 
-		guard let bitmapContext = CGContext(data: nil, width: imageWidth, height: imageHeight, bitsPerComponent: 8, bytesPerRow: imageWidth * 4, space: colorSpace, bitmapInfo: bitmapInfo) else {
-			fatalError("Error creating bitmap context")
+		guard let bitmapContext = bitmapContextFactory(
+			imageWidth,
+			imageHeight,
+			imageWidth * 4,
+			colorSpace,
+			bitmapInfo
+		) else {
+			return self
 		}
 
 		renderingBlock(

--- a/AsyncImageViewTests/ImageInflaterRendererSpec.swift
+++ b/AsyncImageViewTests/ImageInflaterRendererSpec.swift
@@ -9,12 +9,40 @@
 import Quick
 import Nimble
 import CoreGraphics
+import UIKit
 
-import AsyncImageView
+@testable import AsyncImageView
 
 class ImageInflaterRendererSpec: QuickSpec {
     override class func spec() {
         describe("ImageInflaterRenderer") {
+            context("bitmap context creation") {
+                it("returns the original image if context creation fails") {
+                    let image = UIImage()
+                    var didAttemptContextCreation = false
+                    var didRender = false
+
+                    let result = image.processImageWithBitmapContext(
+                        withSize: CGSize(width: 20, height: 30),
+                        scale: 2,
+                        opaque: false,
+                        contentMode: .aspectFill,
+                        bitmapContextFactory: { _, _, _, _, _ in
+                            didAttemptContextCreation = true
+
+                            return nil
+                        },
+                        renderingBlock: { _, _, _, _ in
+                            didRender = true
+                        }
+                    )
+
+                    expect(didAttemptContextCreation) == true
+                    expect(didRender) == false
+                    expect(result).to(beIdenticalTo(image))
+                }
+            }
+
             context("Aspect Fit") {
                 it("returns identity frame if sizes match") {
                     let size = CGSize.random()


### PR DESCRIPTION
## What changed

- return the already-decoded source image when Core Graphics cannot allocate the bitmap context used for inflation
- preserve the existing bitmap inflation and image-processing behavior whenever context creation succeeds
- inject context creation in the internal processing helper so the allocation-failure branch can be tested deterministically
- update CI from Xcode 26.1 to 26.5 so the workflow matches the iOS runtime available on the current GitHub runner

## Why

Watch Chess production crash point `Dnhhtyya-umcNX4vnVhgsP` traps in `ImageInflaterRenderer` when `CGContext(...)` returns `nil`. The renderer currently handles that recoverable resource-allocation failure with `fatalError("Error creating bitmap context")`, terminating the app on its background rendering queue.

Falling back to the decoded image keeps the requested content available without forcing the app to terminate. A later image request can still attempt normal inflation again.

The CI workflow change repairs a pre-existing failure on `master`: the unchanged workflow selected an iOS 26.5 simulator while forcing Xcode 26.1, whose iOS platform is no longer installed on the runner. The failure happened during destination selection before this branch's code compiled.

## Validation

- `swiftlint --config .swiftlint.yml --strict`
- complete `AsyncImageView` iOS simulator test suite: 60 passed, 0 failed
- regression test forces the context factory to return `nil` without a large allocation or OOM
- GitHub Actions `Build and Test` passed with Xcode 26.5
