### PR TITLE
[Tests] Stabilize floating-point geometry assertions

### DIFF
--- a/AsyncImageViewTests/ImageInflaterRendererSpec.swift
+++ b/AsyncImageViewTests/ImageInflaterRendererSpec.swift
@@ -63,7 +63,7 @@ class ImageInflaterRendererSpec: QuickSpec {
                         inSize: canvasSize
                     )
 
-                    expect(result) == CGRect(origin: CGPoint.zero, size: canvasSize)
+                    expectRect(result, toBeCloseTo: CGRect(origin: CGPoint.zero, size: canvasSize))
                 }
 
                 it("scales up size if aspect ratio matches, but canvas is bigger") {
@@ -75,7 +75,7 @@ class ImageInflaterRendererSpec: QuickSpec {
                         inSize: canvasSize
                     )
 
-                    expect(result) == CGRect(origin: CGPoint.zero, size: canvasSize)
+                    expectRect(result, toBeCloseTo: CGRect(origin: CGPoint.zero, size: canvasSize))
                 }
 
                 it("scales and centers image vertically if height matches, but canvas width is smaller") {
@@ -222,7 +222,7 @@ class ImageInflaterRendererSpec: QuickSpec {
                         inSize: canvasSize
                     )
 
-                    expect(result) == CGRect(origin: CGPoint.zero, size: canvasSize)
+                    expectRect(result, toBeCloseTo: CGRect(origin: CGPoint.zero, size: canvasSize))
                 }
 
                 it("scales up size if aspect ratio matches, but canvas is bigger") {
@@ -234,7 +234,7 @@ class ImageInflaterRendererSpec: QuickSpec {
                         inSize: canvasSize
                     )
 
-                    expect(result) == CGRect(origin: CGPoint.zero, size: canvasSize)
+                    expectRect(result, toBeCloseTo: CGRect(origin: CGPoint.zero, size: canvasSize))
                 }
 
                 it("centers image horizontally if height matches, but canvas width is smaller") {
@@ -366,4 +366,16 @@ class ImageInflaterRendererSpec: QuickSpec {
             }
         }
     }
+}
+
+private func expectRect(
+    _ actual: CGRect,
+    toBeCloseTo expected: CGRect,
+    file: FileString = #file,
+    line: UInt = #line
+) {
+    expect(file: file, line: line, actual.origin.x).to(beCloseTo(expected.origin.x))
+    expect(file: file, line: line, actual.origin.y).to(beCloseTo(expected.origin.y))
+    expect(file: file, line: line, actual.size.width).to(beCloseTo(expected.size.width))
+    expect(file: file, line: line, actual.size.height).to(beCloseTo(expected.size.height))
 }


### PR DESCRIPTION
## Summary

- replace exact `CGRect` equality with component-wise closeness checks in the four randomized aspect-preserving scale tests
- keep true identity-path assertions exact
- centralize the approximate rectangle assertions in a small test helper that preserves call-site file and line reporting

## Root cause

The randomized tests derive a canvas size with floating-point multiplication, then the production calculation may recompute the same geometry through division and multiplication. Mathematically equivalent results can therefore differ by a few quadrillionths—for example an origin of `7.1e-15` instead of zero—without indicating a rendering bug.

## Validation

- `ImageInflaterRendererSpec` repeated 50 times: 1,150 tests passed
- full iOS suite: 60 tests passed
- `swiftlint --config .swiftlint.yml --strict`: 0 violations
