### PR TITLE
[Performance] Skip unchanged UIKit image requests

### DIFF
--- a/AsyncImageView/AsyncImageView.swift
+++ b/AsyncImageView/AsyncImageView.swift
@@ -77,13 +77,17 @@ open class AsyncImageView<
 
 	open override var frame: CGRect {
 		didSet {
-			self.requestNewImageIfReady()
+			if self.frame.size != oldValue.size {
+				self.requestNewImageIfReady()
+			}
 		}
 	}
 
 	open override var bounds: CGRect {
 		didSet {
-			self.requestNewImageIfReady()
+			if self.bounds.size != oldValue.size {
+				self.requestNewImageIfReady()
+			}
 		}
 	}
 

--- a/AsyncImageViewTests/AsyncImageViewRequestSpec.swift
+++ b/AsyncImageViewTests/AsyncImageViewRequestSpec.swift
@@ -1,0 +1,84 @@
+import Quick
+import Nimble
+import UIKit
+
+import ReactiveSwift
+
+import AsyncImageView
+
+class AsyncImageViewRequestSpec: QuickSpec {
+	override class func spec() {
+		describe("AsyncImageView requests") {
+			var counter: Atomic<Int>!
+			var view: AsyncImageView<
+				RequestTestRenderData,
+				RequestTestViewData,
+				RequestTestRenderer,
+				RequestTestRenderer
+			>!
+			var window: UIWindow!
+
+			beforeEach {
+				counter = Atomic(0)
+				view = AsyncImageView<
+					RequestTestRenderData,
+					RequestTestViewData,
+					RequestTestRenderer,
+					RequestTestRenderer
+				>(
+					initialFrame: CGRect(origin: .zero, size: CGSize(width: 10, height: 10)),
+					renderer: RequestTestRenderer(),
+					placeholderRenderer: nil,
+					uiScheduler: ImmediateScheduler(),
+					imageCreationScheduler: ImmediateScheduler()
+				)
+				window = UIWindow()
+				window.addSubview(view)
+				view.data = RequestTestViewData(counter: counter)
+			}
+
+			it("does not create render data for frame origin changes") {
+				for offset in 1...10 {
+					view.frame.origin.x = CGFloat(offset)
+				}
+
+				expect(counter.value) == 1
+			}
+
+			it("does not create render data for bounds origin changes") {
+				for offset in 1...10 {
+					view.bounds.origin.x = CGFloat(offset)
+				}
+
+				expect(counter.value) == 1
+			}
+
+			it("creates render data for size changes") {
+				view.frame.size = CGSize(width: 20, height: 20)
+				view.bounds.size = CGSize(width: 30, height: 30)
+
+				expect(counter.value) == 3
+			}
+		}
+	}
+}
+
+private struct RequestTestViewData: ImageViewDataType {
+	let counter: Atomic<Int>
+
+	func renderDataWithSize(_ size: CGSize) -> RequestTestRenderData {
+		self.counter.modify { $0 += 1 }
+
+		return RequestTestRenderData(size: size)
+	}
+}
+
+private struct RequestTestRenderData: RenderDataType {
+	let size: CGSize
+}
+
+private final class RequestTestRenderer: RendererType {
+	func renderImageWithData(_ data: RequestTestRenderData) -> SignalProducer<UIImage, Never> {
+		return SignalProducer(value: UIImage())
+	}
+}


### PR DESCRIPTION
## Summary

- skip `frame` and `bounds` invalidations when only the origin changes
- avoid constructing identical render data and scheduling signal traffic that `skipRepeats` would discard later
- add focused frame, bounds, and real-size-change regression coverage

## Performance

### Isolated AsyncImageView benchmark

100,000 origin-only frame mutations on an iOS simulator:

| | Baseline | This PR | Change |
|---|---:|---:|---:|
| Render-data constructions | 100,000 | 0 | -100% |
| Request scheduler calls | 100,000 | 0 | -100% |
| Mean duration | 2,937.5 ms | 2,632.4 ms | -10.4% |

A 20,000 real-size-change control preserved exactly 20,000 render-data constructions and renderer calls.

### WatchChess integration benchmark

Release-hosted WatchChess benchmark with 64 real `PieceView.ImageView` instances, 2,000 board-layout passes, and 128,000 origin mutations per sample (10 balanced samples per variant):

| | Baseline | This PR | Change |
|---|---:|---:|---:|
| Mean | 328.901 ms | 222.881 ms | -32.24% |
| Median | 329.017 ms | 223.926 ms | -31.94% |
| Request scheduler calls | 128,000 | 0 | -100% |

## Rendering and cache parity

All 20 WatchChess runs produced identical initial, resized, changed-piece, and cache-rendered hashes. Point/pixel dimensions matched, real data and size changes reached the renderer, cold/warm disk-cache behavior remained miss/hit, and multicast behavior remained first miss then repeat hit.

The benchmark also confirmed a pre-existing PNG disk-cache scale-metadata loss (same pixels/hash, different point scale after disk decode) in both variants; this PR does not change it.

## Validation

- `swiftlint --config .swiftlint.yml --strict`
- full iOS simulator suite: 65 tests passed
- Release WatchChess hosted benchmark: 20/20 samples passed correctness assertions