### PR TITLE
[Performance] Remove redundant image scheduler hop

### DIFF
--- a/AsyncImageView/AsyncImageLoader.swift
+++ b/AsyncImageView/AsyncImageLoader.swift
@@ -27,11 +27,9 @@ Renderer.RenderResult == PlaceholderRenderer.RenderResult {
         requestsSignal: Signal<Data?, Never>,
         renderer: Renderer,
         placeholderRenderer: PlaceholderRenderer?,
-        uiScheduler: ReactiveSwift.Scheduler,
-        imageCreationScheduler: ReactiveSwift.Scheduler
+        uiScheduler: ReactiveSwift.Scheduler
     ) -> Signal<Renderer.RenderResult?, Never> {
         return requestsSignal.skipRepeats(==)
-            .observe(on: imageCreationScheduler)
             .flatMap(.latest) { data -> SignalProducer<Renderer.RenderResult?, Never> in
                 let prefixSignal: SignalProducer<Renderer.RenderResult?, Never> = .init(value: nil)
 

--- a/AsyncImageView/AsyncImageView.swift
+++ b/AsyncImageView/AsyncImageView.swift
@@ -59,8 +59,7 @@ open class AsyncImageView<
 			requestsSignal: self.requestsSignal,
 			renderer: renderer,
 			placeholderRenderer: placeholderRenderer,
-			uiScheduler: uiScheduler,
-			imageCreationScheduler: imageCreationScheduler
+			uiScheduler: uiScheduler
 		)
 		.observeValues { [weak self] result in
 			self?.updateImage(result)

--- a/AsyncImageView/AsyncSwiftUIImageView.swift
+++ b/AsyncImageView/AsyncSwiftUIImageView.swift
@@ -178,8 +178,7 @@ private final class AsyncSwiftUIImageViewModel<
             requestsSignal: self.requestsSignal,
             renderer: self.renderer,
             placeholderRenderer: self.placeholderRenderer,
-            uiScheduler: self.uiScheduler,
-            imageCreationScheduler: self.imageCreationScheduler
+            uiScheduler: self.uiScheduler
         )
         .observeValues { [weak self] result in
             self?.renderResult = result

--- a/AsyncImageViewTests/AsyncImageSchedulerSpec.swift
+++ b/AsyncImageViewTests/AsyncImageSchedulerSpec.swift
@@ -1,0 +1,71 @@
+import Quick
+import Nimble
+import UIKit
+
+import ReactiveSwift
+
+import AsyncImageView
+
+class AsyncImageSchedulerSpec: QuickSpec {
+	override class func spec() {
+		describe("AsyncImageView scheduling") {
+			it("schedules image creation once per request") {
+				let imageCreationScheduler = CountingScheduler()
+				let renderer = SchedulerCheckingRenderer(scheduler: imageCreationScheduler)
+				let view = AsyncImageView<
+					TestRenderData,
+					TestData,
+					SchedulerCheckingRenderer,
+					SchedulerCheckingRenderer
+				>(
+					initialFrame: CGRect(origin: .zero, size: CGSize(width: 10, height: 10)),
+					renderer: renderer,
+					placeholderRenderer: nil,
+					uiScheduler: ImmediateScheduler(),
+					imageCreationScheduler: imageCreationScheduler
+				)
+				let window = UIWindow()
+				window.addSubview(view)
+				imageCreationScheduler.reset()
+
+				view.data = .a
+
+				expect(imageCreationScheduler.scheduleCount.value) == 1
+				expect(renderer.startedOnScheduler.value) == true
+			}
+		}
+	}
+}
+
+private final class CountingScheduler: Scheduler {
+	let scheduleCount = Atomic(0)
+	let isExecuting = Atomic(false)
+
+	func schedule(_ action: @escaping () -> Void) -> Disposable? {
+		self.scheduleCount.modify { $0 += 1 }
+		self.isExecuting.modify { $0 = true }
+		action()
+		self.isExecuting.modify { $0 = false }
+
+		return nil
+	}
+
+	func reset() {
+		self.scheduleCount.modify { $0 = 0 }
+	}
+}
+
+private final class SchedulerCheckingRenderer: RendererType {
+	let startedOnScheduler = Atomic(false)
+	private let scheduler: CountingScheduler
+
+	init(scheduler: CountingScheduler) {
+		self.scheduler = scheduler
+	}
+
+	func renderImageWithData(_ data: TestRenderData) -> SignalProducer<UIImage, Never> {
+		self.startedOnScheduler.modify { $0 = self.scheduler.isExecuting.value }
+
+		return SignalProducer(value: UIImage())
+	}
+}


### PR DESCRIPTION
## Summary

- remove the second image-creation scheduler hop after UIKit and SwiftUI have already formed render data on that scheduler
- keep renderer work on the injected image scheduler and final delivery on the UI scheduler
- add focused coverage requiring one scheduling operation per request

## Performance

### Isolated AsyncImageView benchmark

20,000 unique size requests across 10 runs:

| | Baseline | This PR | Change |
|---|---:|---:|---:|
| Scheduler operations | 40,000 | 20,000 | -50% |
| Mean | 1,842.490 ms | 1,690.561 ms | -8.2% |
| Median | 1,792.986 ms | 1,681.549 ms | -6.2% |
| Render-data / renderer calls | 20,000 | 20,000 | unchanged |

### WatchChess integration benchmark

Release-hosted WatchChess benchmark with 96 real `PieceView` requests and 96 repeated hits per sample, 10 strictly alternating samples per variant:

| | Baseline | This PR | Change |
|---|---:|---:|---:|
| Scheduler operations | 192 | 96 | -50% |
| Cold median | 122.068 ms | 123.213 ms | +0.9% (noise) |
| Warm median | 5.308 ms | 5.262 ms | -0.9% (noise) |

The paired cold delta was +0.831 ms (95% CI -1.515 to +3.177 ms); the paired warm delta was -0.097 ms (95% CI -0.631 to +0.436 ms). The app workload confirms the operation reduction, but not a measurable wall-time change.

## Rendering and cache parity

Baseline and candidate matched UIKit and SwiftUI image/snapshot hashes, point and pixel sizes, data/size invalidation sequences, cold/repeated cache semantics, and persistent `miss → hit → hit after renderer recreation` behavior. Every renderer started on the requested image scheduler and every UI callback ran on the main thread.

The benchmark also reproduced a pre-existing disk-reload scale-metadata loss in both variants: raw pixels are preserved while `36 pt @2x` reloads as `72 pt @1x`. This PR does not change it.

## Validation

- `swiftlint --config .swiftlint.yml --strict`
- full iOS simulator suite: 63 tests passed
- WatchChess Release simulator build and 20/20 measured samples passed