### PR TITLE
[Performance] Lazily initialize SwiftUI image state

### DIFF
--- a/AsyncImageView/AsyncSwiftUIImageView.swift
+++ b/AsyncImageView/AsyncSwiftUIImageView.swift
@@ -20,23 +20,82 @@ public struct AsyncSwiftUIImageView<
     Renderer.Error == Never,
     PlaceholderRenderer.Data == Data,
     PlaceholderRenderer.Error == Never,
-Renderer.RenderResult == PlaceholderRenderer.RenderResult {
+    Renderer.RenderResult == PlaceholderRenderer.RenderResult {
     private typealias ViewModel = AsyncSwiftUIImageViewModel<Data, ImageViewData, Renderer, PlaceholderRenderer>
 
-    @State private var viewModel: ViewModel
+    @State private var viewModelReference: LazyReference<ViewModel>
+
+    private var viewModel: ViewModel {
+        self.viewModelReference.value
+    }
+
+    public init(
+        renderer: Renderer,
+        placeholderRenderer: PlaceholderRenderer? = nil
+    ) {
+        self.init(
+            renderer: renderer,
+            placeholderRenderer: placeholderRenderer,
+            uiSchedulerFactory: { UIScheduler() },
+            imageCreationSchedulerFactory: { QueueScheduler() }
+        )
+    }
 
     public init(
         renderer: Renderer,
         placeholderRenderer: PlaceholderRenderer? = nil,
-        uiScheduler: ReactiveSwift.Scheduler = UIScheduler(),
-        imageCreationScheduler: ReactiveSwift.Scheduler = QueueScheduler()) {
-        _viewModel = State(
-            initialValue: ViewModel(
-                renderer: renderer,
-                placeholderRenderer: placeholderRenderer,
-                uiScheduler: uiScheduler,
-                imageCreationScheduler: imageCreationScheduler
-            )
+        uiScheduler: ReactiveSwift.Scheduler
+    ) {
+        self.init(
+            renderer: renderer,
+            placeholderRenderer: placeholderRenderer,
+            uiSchedulerFactory: { uiScheduler },
+            imageCreationSchedulerFactory: { QueueScheduler() }
+        )
+    }
+
+    public init(
+        renderer: Renderer,
+        placeholderRenderer: PlaceholderRenderer? = nil,
+        imageCreationScheduler: ReactiveSwift.Scheduler
+    ) {
+        self.init(
+            renderer: renderer,
+            placeholderRenderer: placeholderRenderer,
+            uiSchedulerFactory: { UIScheduler() },
+            imageCreationSchedulerFactory: { imageCreationScheduler }
+        )
+    }
+
+    public init(
+        renderer: Renderer,
+        placeholderRenderer: PlaceholderRenderer? = nil,
+        uiScheduler: ReactiveSwift.Scheduler,
+        imageCreationScheduler: ReactiveSwift.Scheduler
+    ) {
+        self.init(
+            renderer: renderer,
+            placeholderRenderer: placeholderRenderer,
+            uiSchedulerFactory: { uiScheduler },
+            imageCreationSchedulerFactory: { imageCreationScheduler }
+        )
+    }
+
+    internal init(
+        renderer: Renderer,
+        placeholderRenderer: PlaceholderRenderer?,
+        uiSchedulerFactory: @escaping () -> ReactiveSwift.Scheduler,
+        imageCreationSchedulerFactory: @escaping () -> ReactiveSwift.Scheduler
+    ) {
+        _viewModelReference = State(
+            initialValue: LazyReference {
+                ViewModel(
+                    renderer: renderer,
+                    placeholderRenderer: placeholderRenderer,
+                    uiScheduler: uiSchedulerFactory(),
+                    imageCreationScheduler: imageCreationSchedulerFactory()
+                )
+            }
         )
     }
 
@@ -98,6 +157,19 @@ Renderer.RenderResult == PlaceholderRenderer.RenderResult {
         }
 
         self.viewModel.requestImage(self.data, size: self.size)
+    }
+}
+
+private final class LazyReference<Value> {
+    private let factory: () -> Value
+    private lazy var storedValue = self.factory()
+
+    var value: Value {
+        self.storedValue
+    }
+
+    init(factory: @escaping () -> Value) {
+        self.factory = factory
     }
 }
 

--- a/AsyncImageViewTests/AsyncSwiftUIImageViewStateSpec.swift
+++ b/AsyncImageViewTests/AsyncSwiftUIImageViewStateSpec.swift
@@ -1,0 +1,110 @@
+import Quick
+import Nimble
+import SwiftUI
+import UIKit
+
+import ReactiveSwift
+
+@testable import AsyncImageView
+
+class AsyncSwiftUIImageViewStateSpec: QuickSpec {
+    override class func spec() {
+        describe("AsyncSwiftUIImageView state") {
+            it("preserves every scheduler initializer combination") {
+                let renderer = StateTestRenderer()
+
+                _ = StateTestImageView(renderer: renderer)
+                _ = StateTestImageView(renderer: renderer, uiScheduler: ImmediateScheduler())
+                _ = StateTestImageView(renderer: renderer, imageCreationScheduler: ImmediateScheduler())
+                _ = StateTestImageView(
+                    renderer: renderer,
+                    uiScheduler: ImmediateScheduler(),
+                    imageCreationScheduler: ImmediateScheduler()
+                )
+            }
+
+            it("creates its retained schedulers only once across parent updates") {
+                let schedulerFactory = SchedulerFactory()
+                let renderer = StateTestRenderer()
+                let initialView = StateTestContainer(
+                    generation: 0,
+                    renderer: renderer,
+                    schedulerFactory: schedulerFactory
+                )
+                let viewController = UIHostingController(rootView: initialView)
+                let window = UIWindow(frame: CGRect(origin: .zero, size: CGSize(width: 100, height: 100)))
+                window.rootViewController = viewController
+                window.makeKeyAndVisible()
+                viewController.view.frame = window.bounds
+                viewController.view.layoutIfNeeded()
+
+                for generation in 1...100 {
+                    viewController.rootView = StateTestContainer(
+                        generation: generation,
+                        renderer: renderer,
+                        schedulerFactory: schedulerFactory
+                    )
+                    viewController.view.layoutIfNeeded()
+                }
+
+                expect(schedulerFactory.uiSchedulerCount.value) == 1
+                expect(schedulerFactory.imageSchedulerCount.value) == 1
+            }
+        }
+    }
+}
+
+private struct StateTestContainer: View {
+    let generation: Int
+    let renderer: StateTestRenderer
+    let schedulerFactory: SchedulerFactory
+
+    var body: some View {
+        StateTestImageView(
+            renderer: self.renderer,
+            placeholderRenderer: nil,
+            uiSchedulerFactory: self.schedulerFactory.makeUIScheduler,
+            imageCreationSchedulerFactory: self.schedulerFactory.makeImageScheduler
+        )
+        .frame(width: 100, height: 100)
+        .accessibilityIdentifier("generation-\(self.generation)")
+    }
+}
+
+private typealias StateTestImageView = AsyncSwiftUIImageView<
+    StateTestRenderData,
+    StateTestViewData,
+    StateTestRenderer,
+    StateTestRenderer
+>
+
+private final class SchedulerFactory {
+    let uiSchedulerCount = Atomic(0)
+    let imageSchedulerCount = Atomic(0)
+
+    func makeUIScheduler() -> ReactiveSwift.Scheduler {
+        self.uiSchedulerCount.modify { $0 += 1 }
+        return ImmediateScheduler()
+    }
+
+    func makeImageScheduler() -> ReactiveSwift.Scheduler {
+        self.imageSchedulerCount.modify { $0 += 1 }
+        return ImmediateScheduler()
+    }
+}
+
+private struct StateTestViewData: ImageViewDataType {
+    func renderDataWithSize(_ size: CGSize) -> StateTestRenderData {
+        StateTestRenderData(size: size)
+    }
+}
+
+private struct StateTestRenderData: RenderDataType {
+    let size: CGSize
+}
+
+private final class StateTestRenderer: RendererType {
+    func renderImageWithData(_ data: StateTestRenderData) -> SignalProducer<UIImage, Never> {
+        SignalProducer(value: UIImage())
+    }
+}


### PR DESCRIPTION
## Summary

- defer SwiftUI image view-model creation until the retained `@State` reference is first used
- avoid constructing discarded view models, signal pipes, and default schedulers during parent-view reconstruction
- preserve every existing scheduler initializer call pattern and add focused state-lifetime coverage

## Performance

### Isolated AsyncImageView benchmark

1,000 `UIHostingController` root-view updates:

| | Baseline | This PR | Change |
|---|---:|---:|---:|
| Median | 33.654 ms | 28.246 ms | -16.1% |
| View models created | 1,001 | 1 | -99.9% |
| Default UI schedulers created | 1,001 | 1 | -99.9% |
| Default image queues created | 1,001 | 1 | -99.9% |

### WatchChess integration benchmark

Release-hosted WatchChess benchmark through the real `PlayerPictureView.createSwiftUIView()` path, 20,000 forced SwiftUI body reconstructions per sample and 12 balanced pairs per variant:

| | Baseline | This PR | Change |
|---|---:|---:|---:|
| Mean per reconstruction | 39.381 µs | 37.632 µs | -4.44% |
| Median | 39.232 µs | 37.587 µs | -4.19% |
| Mean per 20,000 updates | 787.62 ms | 752.65 ms | -34.97 ms |

The candidate won 12/12 pairs. Paired mean saving was 1.749 µs per reconstruction (95% CI 1.400–2.097 µs; p < 0.000001), or about 1.75 ms per 1,000 reconstructions.

WatchChess explicitly constructs lightweight `SynchronousUIScheduler` and `ImmediateScheduler` values at the call site; those allocations remain. The measured app gain comes from avoiding discarded view models and signal pipes.

## Rendering and cache parity

Baseline and candidate matched exact direct-render, hosted-view, emitted-result, resized, and alternate-data pixel hashes and output dimensions. Both preserved first-request miss / repeat-request hit behavior.

The benchmark also confirmed the same pre-existing stable-size `.data(...)` update issue in both versions: a data-only update does not issue a second request until size changes. This PR does not alter it.

## Validation

- `swiftlint --config .swiftlint.yml --strict`
- full iOS simulator suite: 64 tests passed
- 24/24 WatchChess Release timing samples completed with the exact body-evaluation count
- baseline and candidate WatchChess rendering/cache parity suites passed