### PR TITLE
[Performance] Reduce multicast renderer contention

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: macos-26
     timeout-minutes: 30
     env:
       CI: true

--- a/AsyncImageView/Renderers/MulticastedRenderer.swift
+++ b/AsyncImageView/Renderers/MulticastedRenderer.swift
@@ -14,11 +14,29 @@ private final class InFlightImage {
 	let result: Property<ImageResult?>
 	let observer: Signal<ImageResult, Never>.Observer
 	let disposable = SerialDisposable()
+	private let hasStarted = Atomic(false)
 
 	init() {
 		let (signal, observer) = Signal<ImageResult, Never>.pipe()
 		self.result = Property(initial: nil, then: signal)
 		self.observer = observer
+	}
+
+	deinit {
+		self.disposable.dispose()
+	}
+
+	func startIfNeeded(_ action: () -> Void) {
+		let shouldStart = self.hasStarted.modify { hasStarted in
+			guard !hasStarted else { return false }
+			hasStarted = true
+
+			return true
+		}
+
+		if shouldStart {
+			action()
+		}
 	}
 }
 
@@ -28,7 +46,7 @@ private enum CachedImage {
 }
 
 private enum CachedImageLookup {
-	case rendering(InFlightImage, shouldStart: Bool)
+	case rendering(InFlightImage)
 	case completed(ImageResult)
 }
 
@@ -68,11 +86,7 @@ public final class MulticastedRenderer<
 		case let .completed(result):
 			return SignalProducer(value: result)
 
-		case let .rendering(entry, shouldStart):
-			if shouldStart {
-				self.startRendering(data, into: entry)
-			}
-
+		case let .rendering(entry):
 			return self.producer(for: data, entry: entry)
 		}
 	}
@@ -84,13 +98,13 @@ public final class MulticastedRenderer<
 				return .completed(result)
 
 			case let .rendering(entry, latest: nil):
-				return .rendering(entry, shouldStart: false)
+				return .rendering(entry)
 
 			case nil:
 				let entry = InFlightImage()
 				cache[data] = .rendering(entry, latest: nil)
 
-				return .rendering(entry, shouldStart: true)
+				return .rendering(entry)
 			}
 		}
 	}
@@ -117,8 +131,8 @@ public final class MulticastedRenderer<
 		)
 
 		guard result.shouldCache else {
-			entry.observer.send(value: cacheMiss)
 			self.remove(entry, for: data)
+			entry.observer.send(value: cacheMiss)
 
 			return
 		}
@@ -150,8 +164,13 @@ public final class MulticastedRenderer<
 	}
 
 	private func producer(for data: Data, entry: InFlightImage) -> SignalProducer<ImageResult, Never> {
-		return SignalProducer { [weak self, entry] observer, lifetime in
-			let cachedResult = self?.cache.withValue { cache -> ImageResult? in
+		return SignalProducer { [self, entry] observer, lifetime in
+			lifetime.observeEnded {
+				_ = self
+				_ = entry
+			}
+
+			let cachedResult = self.cache.withValue { cache -> ImageResult? in
 				switch cache[data] {
 				case let .completed(result), let .rendering(_, latest: result?):
 					return result
@@ -161,9 +180,17 @@ public final class MulticastedRenderer<
 				}
 			}
 
-			let producer = cachedResult.map(SignalProducer.init(value:))
-				?? entry.result.producer.compactMap { $0 }.take(first: 1)
-			lifetime += producer.start(observer)
+			if let cachedResult {
+				lifetime += SignalProducer(value: cachedResult).start(observer)
+			} else {
+				lifetime += entry.result.producer
+					.compactMap { $0 }
+					.take(first: 1)
+					.start(observer)
+				entry.startIfNeeded {
+					self.startRendering(data, into: entry)
+				}
+			}
 		}
 	}
 

--- a/AsyncImageView/Renderers/MulticastedRenderer.swift
+++ b/AsyncImageView/Renderers/MulticastedRenderer.swift
@@ -165,6 +165,8 @@ public final class MulticastedRenderer<
 
 	private func producer(for data: Data, entry: InFlightImage) -> SignalProducer<ImageResult, Never> {
 		return SignalProducer { [self, entry] observer, lifetime in
+			// Keep async callbacks deliverable after cache eviction or a temporary wrapper.
+			// `Lifetime` releases this action on completion or cancellation.
 			lifetime.observeEnded {
 				_ = self
 				_ = entry

--- a/AsyncImageView/Renderers/MulticastedRenderer.swift
+++ b/AsyncImageView/Renderers/MulticastedRenderer.swift
@@ -10,8 +10,27 @@ import UIKit
 
 import ReactiveSwift
 
-// The initial value is `nil`.
-private typealias ImageProperty = Property<ImageResult?>
+private final class InFlightImage {
+	let result: Property<ImageResult?>
+	let observer: Signal<ImageResult, Never>.Observer
+	let disposable = SerialDisposable()
+
+	init() {
+		let (signal, observer) = Signal<ImageResult, Never>.pipe()
+		self.result = Property(initial: nil, then: signal)
+		self.observer = observer
+	}
+}
+
+private enum CachedImage {
+	case rendering(InFlightImage, latest: ImageResult?)
+	case completed(ImageResult)
+}
+
+private enum CachedImageLookup {
+	case rendering(InFlightImage, shouldStart: Bool)
+	case completed(ImageResult)
+}
 
 /// `RendererType` decorator which guarantees that images for a given `RenderDataType`
 /// are only rendered once, and multicasted to every observer.
@@ -23,7 +42,7 @@ public final class MulticastedRenderer<
 	Renderer.Data == Data,
 	Renderer.Error == Never {
 	private let renderer: Renderer
-	private let cache: Atomic<[Data: ImageProperty]>
+	private let cache: Atomic<[Data: CachedImage]>
 
     #if !os(watchOS)
 	private let memoryWarningDisposable: Disposable
@@ -45,36 +64,111 @@ public final class MulticastedRenderer<
 	}
 
 	public func renderImageWithData(_ data: Data) -> SignalProducer<ImageResult, Never> {
-		let property = getPropertyForData(data)
+		switch self.lookup(for: data) {
+		case let .completed(result):
+			return SignalProducer(value: result)
 
-		return property.producer
-			.filter { $0 != nil } // Skip initial `nil` value.
-			.map { $0! }
-			.take(first: 1)
- 	}
+		case let .rendering(entry, shouldStart):
+			if shouldStart {
+				self.startRendering(data, into: entry)
+			}
 
-	private func getPropertyForData(_ data: Data) -> ImageProperty {
-		var result: ImageProperty!
+			return self.producer(for: data, entry: entry)
+		}
+	}
 
-		self.cache.modify { cache in
-			if let property = cache[data] {
-				result = property
-			} else {
-				result = ImageProperty(
-					initial: nil,
-					then: renderer.createProducerForRenderingData(data)
-						.map(Optional.init)
-				)
+	private func lookup(for data: Data) -> CachedImageLookup {
+		return self.cache.modify { cache in
+			switch cache[data] {
+			case let .completed(result), let .rendering(_, latest: result?):
+				return .completed(result)
 
-				cache[data] = result
+			case let .rendering(entry, latest: nil):
+				return .rendering(entry, shouldStart: false)
+
+			case nil:
+				let entry = InFlightImage()
+				cache[data] = .rendering(entry, latest: nil)
+
+				return .rendering(entry, shouldStart: true)
 			}
 		}
+	}
 
-		return result
+	private func startRendering(_ data: Data, into entry: InFlightImage) {
+		entry.disposable.inner = self.renderer
+			.renderImageWithData(data)
+			.start { [weak self, weak entry] event in
+				guard let self, let entry else { return }
+
+				if let result = event.value {
+					self.receive(result, for: data, entry: entry)
+				} else if event.isTerminating {
+					self.finishRendering(data, entry: entry)
+				}
+			}
+	}
+
+	private func receive(_ result: Renderer.RenderResult, for data: Data, entry: InFlightImage) {
+		let cacheMiss = ImageResult(
+			image: result.image,
+			cacheHit: false,
+			shouldCache: result.shouldCache
+		)
+
+		guard result.shouldCache else {
+			entry.observer.send(value: cacheMiss)
+			self.remove(entry, for: data)
+
+			return
+		}
+
+		let cacheHit = ImageResult(image: result.image, cacheHit: true, shouldCache: true)
+		self.cache.modify { cache in
+			guard case let .rendering(current, _) = cache[data], current === entry else { return }
+			cache[data] = .rendering(entry, latest: cacheHit)
+		}
+
+		entry.observer.send(value: cacheMiss)
+		entry.observer.send(value: cacheHit)
+	}
+
+	private func finishRendering(_ data: Data, entry: InFlightImage) {
+		self.cache.modify { cache in
+			guard case let .rendering(current, latest) = cache[data], current === entry else { return }
+
+			cache[data] = latest.map(CachedImage.completed)
+		}
+		entry.observer.sendCompleted()
+	}
+
+	private func remove(_ entry: InFlightImage, for data: Data) {
+		self.cache.modify { cache in
+			guard case let .rendering(current, _) = cache[data], current === entry else { return }
+			cache[data] = nil
+		}
+	}
+
+	private func producer(for data: Data, entry: InFlightImage) -> SignalProducer<ImageResult, Never> {
+		return SignalProducer { [weak self, entry] observer, lifetime in
+			let cachedResult = self?.cache.withValue { cache -> ImageResult? in
+				switch cache[data] {
+				case let .completed(result), let .rendering(_, latest: result?):
+					return result
+
+				case .rendering(_, latest: nil), nil:
+					return nil
+				}
+			}
+
+			let producer = cachedResult.map(SignalProducer.init(value:))
+				?? entry.result.producer.compactMap { $0 }.take(first: 1)
+			lifetime += producer.start(observer)
+		}
 	}
 
     #if !os(watchOS)
-	private static func clearCacheOnMemoryWarning(_ cache: Atomic<[Data: ImageProperty]>) -> Disposable {
+	private static func clearCacheOnMemoryWarning(_ cache: Atomic<[Data: CachedImage]>) -> Disposable {
 		return NotificationCenter.default
 			.reactive.notifications(forName: UIApplication.didReceiveMemoryWarningNotification, object: nil)
 			.observe(on: QueueScheduler())
@@ -89,17 +183,5 @@ extension RendererType where Error == Never {
 	/// Multicasts the results of this `RendererType`.
 	public func multicasted() -> MulticastedRenderer<Self, Self.Data> {
 		return MulticastedRenderer(renderer: self)
-	}
-}
-
-extension RendererType {
-	fileprivate func createProducerForRenderingData(_ data: Data) -> SignalProducer<ImageResult, Error> {
-		return self.renderImageWithData(data)
-			.flatMap(.concat) { result in
-				return SignalProducer([
-					ImageResult(image: result.image, cacheHit: false, shouldCache: result.shouldCache),
-					ImageResult(image: result.image, cacheHit: true, shouldCache: result.shouldCache)
-				])
-		}
 	}
 }

--- a/AsyncImageViewTests/MulticastedRendererSpec.swift
+++ b/AsyncImageViewTests/MulticastedRendererSpec.swift
@@ -127,15 +127,14 @@ class MulticastedRendererSpec: QuickSpec {
 					expect(getCacheHitValue()) == false
 				}
 
-				it("is a cache hit the second time the producer is fetched") {
-					let producer = getProducerForData(data, size)
+				it("is a cache hit after the initial producer completes") {
+					var initialResult: ImageResult?
+					getProducerForData(data, size).startWithValues { initialResult = $0 }
 					scheduler.advance(by: interval)
+					expect(initialResult).toEventuallyNot(beNil())
 
-					var result: ImageResult?
-					producer.startWithValues { result = $0 }
-
-					expect(result).toEventuallyNot(beNil())
-					expect(result?.cacheHit) == true
+					expect(initialResult?.cacheHit) == false
+					expect(getImageForData(data, size)?.cacheHit) == true
 				}
 			}
 		}

--- a/AsyncImageViewTests/MulticastedRendererTests.swift
+++ b/AsyncImageViewTests/MulticastedRendererTests.swift
@@ -176,14 +176,39 @@ struct MulticastedRendererTests {
 	func cancelsInFlightWorkWhenTheRendererIsReleased() {
 		let source = CancellableRenderer()
 		var renderer: MulticastedRenderer<CancellableRenderer, MulticastRenderData>? = source.multicasted()
+		weak var weakRenderer = renderer
 		let disposable = renderer?.renderImageWithData(MulticastRenderData(identifier: 1)).start()
 
 		#expect(source.started.value == true)
 		#expect(source.cancelled.value == false)
-		disposable?.dispose()
 		renderer = nil
+		#expect(weakRenderer != nil)
+		disposable?.dispose()
 
 		#expect(source.cancelled.value == true)
+		#expect(weakRenderer == nil)
+	}
+
+	@Test
+	func releasesTheRendererWhenAnActiveProducerCompletes() throws {
+		let image = makeImage()
+		let source = MultiValueRenderer()
+		var renderer: MulticastedRenderer<MultiValueRenderer, MulticastRenderData>? = source.multicasted()
+		weak var weakRenderer = renderer
+		var result: ImageResult?
+		let disposable = renderer?
+			.renderImageWithData(MulticastRenderData(identifier: 1))
+			.startWithValues { result = $0 }
+		defer { disposable?.dispose() }
+
+		renderer = nil
+		#expect(weakRenderer != nil)
+		source.observer.send(value: image)
+
+		let rendered = try #require(result)
+		#expect(rendered.image === image)
+		#expect(weakRenderer == nil)
+		source.observer.sendCompleted()
 	}
 
 	@Test

--- a/AsyncImageViewTests/MulticastedRendererTests.swift
+++ b/AsyncImageViewTests/MulticastedRendererTests.swift
@@ -1,0 +1,222 @@
+//
+//  MulticastedRendererTests.swift
+//  AsyncImageViewTests
+//
+//  Created by Nacho Soto on 7/11/26.
+//  Copyright © 2026 Nacho Soto. All rights reserved.
+//
+
+import Foundation
+import Testing
+import UIKit
+
+import ReactiveSwift
+
+@testable import AsyncImageView
+
+@Suite
+struct MulticastedRendererTests {
+	@Test
+	func rendersDifferentKeysConcurrently() {
+		let source = BlockingRenderer()
+		let renderer = UncheckedSendable(source.multicasted())
+		let group = DispatchGroup()
+		let queue = DispatchQueue(label: #function, attributes: .concurrent)
+
+		for identifier in 0..<2 {
+			group.enter()
+			queue.async {
+				let data = MulticastRenderData(identifier: identifier)
+				_ = renderer.value.renderImageWithData(data).single()
+				group.leave()
+			}
+		}
+
+		let firstStarted = source.started.wait(timeout: .now() + 2)
+		let secondStarted = source.started.wait(timeout: .now() + 2)
+		source.release.signal()
+		source.release.signal()
+		let completed = group.wait(timeout: .now() + 2)
+
+		#expect(firstStarted == .success)
+		#expect(secondStarted == .success)
+		#expect(completed == .success)
+	}
+
+	@Test
+	func preservesTheLatestValueFromAMultiValueRenderer() throws {
+		let firstImage = makeImage(size: CGSize(width: 16, height: 16))
+		let secondImage = makeImage(size: CGSize(width: 32, height: 32))
+		let source = MultiValueRenderer()
+		let renderer = source.multicasted()
+		let data = MulticastRenderData(identifier: 1)
+		var initial: ImageResult?
+		let disposable = renderer.renderImageWithData(data).startWithValues { initial = $0 }
+		defer { disposable.dispose() }
+
+		source.observer.send(value: firstImage)
+		let firstHit = try #require(renderer.renderImageWithData(data).single()?.get())
+
+		source.observer.send(value: secondImage)
+		let secondHit = try #require(renderer.renderImageWithData(data).single()?.get())
+
+		source.observer.sendCompleted()
+		let completedHit = try #require(renderer.renderImageWithData(data).single()?.get())
+
+		#expect(source.renderCount == 1)
+		#expect(initial?.image === firstImage)
+		#expect(initial?.cacheHit == false)
+		#expect(firstHit.image === firstImage)
+		#expect(firstHit.cacheHit == true)
+		#expect(secondHit.image === secondImage)
+		#expect(secondHit.cacheHit == true)
+		#expect(completedHit.image === secondImage)
+		#expect(completedHit.cacheHit == true)
+	}
+
+	@Test
+	func sharesOneUpstreamRenderBetweenConcurrentWaiters() throws {
+		let image = makeImage()
+		let source = MultiValueRenderer()
+		let renderer = source.multicasted()
+		let data = MulticastRenderData(identifier: 1)
+		let firstProducer = renderer.renderImageWithData(data)
+		let secondProducer = renderer.renderImageWithData(data)
+		var first: ImageResult?
+		var second: ImageResult?
+		let firstDisposable = firstProducer.startWithValues { first = $0 }
+		let secondDisposable = secondProducer.startWithValues { second = $0 }
+		defer {
+			firstDisposable.dispose()
+			secondDisposable.dispose()
+		}
+
+		source.observer.send(value: image)
+		source.observer.sendCompleted()
+
+		let firstResult = try #require(first)
+		let secondResult = try #require(second)
+		#expect(source.renderCount == 1)
+		#expect(firstResult.image === image)
+		#expect(secondResult.image === image)
+		#expect(firstResult.cacheHit == false)
+		#expect(secondResult.cacheHit == false)
+	}
+
+	@Test
+	func retriesAfterANonCacheableResult() throws {
+		let source = RecoveringRenderer()
+		let renderer = source.multicasted()
+		let data = MulticastRenderData(identifier: 1)
+
+		let failed = try #require(renderer.renderImageWithData(data).single()?.get())
+		let recovered = try #require(renderer.renderImageWithData(data).single()?.get())
+		let cached = try #require(renderer.renderImageWithData(data).single()?.get())
+
+		#expect(source.renderCount == 2)
+		#expect(failed.cacheHit == false)
+		#expect(failed.shouldCache == false)
+		#expect(recovered.shouldCache == true)
+		#expect(cached.cacheHit == true)
+	}
+
+	@Test
+	func retriesAfterTheUpstreamCompletesWithoutAValue() throws {
+		let source = EmptyThenValueRenderer()
+		let renderer = source.multicasted()
+		let data = MulticastRenderData(identifier: 1)
+
+		let empty = renderer.renderImageWithData(data).single()
+		let recovered = try #require(renderer.renderImageWithData(data).single()?.get())
+		let cached = try #require(renderer.renderImageWithData(data).single()?.get())
+
+		#expect(empty == nil)
+		#expect(source.renderCount == 2)
+		#expect(recovered.image === source.image)
+		#expect(cached.image === source.image)
+		#expect(cached.cacheHit == true)
+	}
+}
+
+private struct MulticastRenderData: RenderDataType, Sendable {
+	let identifier: Int
+	let size = CGSize(width: 8, height: 8)
+}
+
+private struct UncheckedSendable<Value>: @unchecked Sendable {
+	let value: Value
+
+	init(_ value: Value) {
+		self.value = value
+	}
+}
+
+private final class BlockingRenderer: RendererType, @unchecked Sendable {
+	let started = DispatchSemaphore(value: 0)
+	let release = DispatchSemaphore(value: 0)
+
+	private let image = makeImage()
+
+	func renderImageWithData(_ data: MulticastRenderData) -> SignalProducer<UIImage, Never> {
+		return SignalProducer { [image = self.image, release = self.release, started = self.started] observer, lifetime in
+			started.signal()
+			release.wait()
+
+			guard !lifetime.hasEnded else { return }
+
+			observer.send(value: image)
+			observer.sendCompleted()
+		}
+	}
+}
+
+private final class MultiValueRenderer: RendererType {
+	let signal: Signal<UIImage, Never>
+	let observer: Signal<UIImage, Never>.Observer
+	private(set) var renderCount = 0
+
+	init() {
+		(self.signal, self.observer) = Signal.pipe()
+	}
+
+	func renderImageWithData(_ data: MulticastRenderData) -> SignalProducer<UIImage, Never> {
+		self.renderCount += 1
+
+		return self.signal.producer
+	}
+}
+
+private final class RecoveringRenderer: RendererType {
+	private let image = makeImage()
+	private let scheduler = QueueScheduler(name: "MulticastedRendererTests.RecoveringRenderer")
+	private(set) var renderCount = 0
+
+	func renderImageWithData(_ data: MulticastRenderData) -> SignalProducer<ImageResult, Never> {
+		self.renderCount += 1
+		let result = ImageResult(
+			image: self.image,
+			cacheHit: false,
+			shouldCache: self.renderCount > 1
+		)
+
+		return SignalProducer(value: result)
+			.start(on: self.scheduler)
+	}
+}
+
+private final class EmptyThenValueRenderer: RendererType {
+	let image = makeImage()
+	private(set) var renderCount = 0
+
+	func renderImageWithData(_ data: MulticastRenderData) -> SignalProducer<UIImage, Never> {
+		self.renderCount += 1
+
+		return self.renderCount == 1
+			? SignalProducer.empty
+			: SignalProducer(value: self.image)
+	}
+}
+
+private func makeImage(size: CGSize = CGSize(width: 8, height: 8)) -> UIImage {
+	return UIGraphicsImageRenderer(size: size).image { _ in }
+}

--- a/AsyncImageViewTests/MulticastedRendererTests.swift
+++ b/AsyncImageViewTests/MulticastedRendererTests.swift
@@ -14,7 +14,7 @@ import ReactiveSwift
 
 @testable import AsyncImageView
 
-@Suite
+@Suite(.serialized)
 struct MulticastedRendererTests {
 	@Test
 	func rendersDifferentKeysConcurrently() {
@@ -75,6 +75,22 @@ struct MulticastedRendererTests {
 	}
 
 	@Test
+	func preservesTheInitialCacheMissFromASynchronousRenderer() throws {
+		let source = SynchronousRenderer()
+		let renderer = source.multicasted()
+		let data = MulticastRenderData(identifier: 1)
+
+		let initial = try #require(renderer.renderImageWithData(data).single()?.get())
+		let cached = try #require(renderer.renderImageWithData(data).single()?.get())
+
+		#expect(source.renderCount == 1)
+		#expect(initial.image === source.image)
+		#expect(initial.cacheHit == false)
+		#expect(cached.image === source.image)
+		#expect(cached.cacheHit == true)
+	}
+
+	@Test
 	func sharesOneUpstreamRenderBetweenConcurrentWaiters() throws {
 		let image = makeImage()
 		let source = MultiValueRenderer()
@@ -101,6 +117,73 @@ struct MulticastedRendererTests {
 		#expect(secondResult.image === image)
 		#expect(firstResult.cacheHit == false)
 		#expect(secondResult.cacheHit == false)
+	}
+
+	@Test
+	func producerOutlivesATemporaryMulticastedRenderer() throws {
+		let image = makeImage()
+		let source = MultiValueRenderer()
+		let data = MulticastRenderData(identifier: 1)
+		let producer = source.multicasted().renderImageWithData(data)
+		var result: ImageResult?
+		let disposable = producer.startWithValues { result = $0 }
+		defer { disposable.dispose() }
+
+		source.observer.send(value: image)
+		source.observer.sendCompleted()
+
+		let rendered = try #require(result)
+		#expect(source.renderCount == 1)
+		#expect(rendered.image === image)
+		#expect(rendered.cacheHit == false)
+	}
+
+	@Test
+	func preservesInFlightDeliveryAcrossAMemoryWarning() throws {
+		let image = makeImage()
+		let source = MultiValueRenderer()
+		let renderer = source.multicasted()
+		let data = MulticastRenderData(identifier: 1)
+		var first: ImageResult?
+		let firstDisposable = renderer.renderImageWithData(data).startWithValues { first = $0 }
+		var secondDisposable: Disposable?
+		defer {
+			firstDisposable.dispose()
+			secondDisposable?.dispose()
+		}
+
+		#expect(source.renderCount == 1)
+		NotificationCenter.default.post(name: UIApplication.didReceiveMemoryWarningNotification, object: nil)
+
+		for _ in 0..<100 where source.renderCount < 2 {
+			secondDisposable?.dispose()
+			secondDisposable = renderer.renderImageWithData(data).start()
+			if source.renderCount < 2 {
+				Thread.sleep(forTimeInterval: 0.01)
+			}
+		}
+
+		#expect(source.renderCount == 2)
+		source.observer.send(value: image)
+		source.observer.sendCompleted()
+
+		let rendered = try #require(first)
+		#expect(rendered.image === image)
+		#expect(rendered.cacheHit == false)
+	}
+
+	@Test
+	func cancelsInFlightWorkWhenTheRendererIsReleased() {
+		let source = CancellableRenderer()
+		var renderer: MulticastedRenderer<CancellableRenderer, MulticastRenderData>? = source.multicasted()
+		let disposable = renderer?.renderImageWithData(MulticastRenderData(identifier: 1)).start()
+
+		#expect(source.started.value == true)
+		#expect(source.cancelled.value == false)
+		disposable?.dispose()
+		renderer = nil
+
+		#expect(source.cancelled.value == true)
 	}
 
 	@Test
@@ -183,6 +266,31 @@ private final class MultiValueRenderer: RendererType {
 		self.renderCount += 1
 
 		return self.signal.producer
+	}
+}
+
+private final class SynchronousRenderer: RendererType {
+	let image = makeImage()
+	private(set) var renderCount = 0
+
+	func renderImageWithData(_ data: MulticastRenderData) -> SignalProducer<UIImage, Never> {
+		self.renderCount += 1
+
+		return SignalProducer(value: self.image)
+	}
+}
+
+private final class CancellableRenderer: RendererType {
+	let started = Atomic(false)
+	let cancelled = Atomic(false)
+
+	func renderImageWithData(_ data: MulticastRenderData) -> SignalProducer<UIImage, Never> {
+		return SignalProducer { [cancelled = self.cancelled, started = self.started] _, lifetime in
+			started.modify { $0 = true }
+			lifetime.observeEnded {
+				cancelled.modify { $0 = true }
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- replace the globally locked property cache with explicit in-flight and completed states
- release the cache lock before renderer work while retaining one shared upstream render per key
- return completed hits directly and preserve the latest value from multi-value renderers
- start rendering atomically only after the first subscriber attaches, preserving the initial cache miss
- keep active async state alive through completion/cancellation and dispose in-flight work when its entry is released
- evict empty, interrupted, and non-cacheable attempts so later requests can recover
- add focused concurrency, synchronous, lifetime, memory-warning, cancellation, multi-value, and retry coverage

## Performance

### Isolated AsyncImageView benchmarks

| Workload | Baseline | This PR | Change |
|---|---:|---:|---:|
| 8 distinct synchronous 20 ms renders | 207–218 ms | 28–30 ms | about -86% |
| 10,000 completed-cache hits | 63–66 ms | 19–20 ms | about -69% |

### WatchChess integration benchmark

Release-hosted WatchChess benchmark with real `PieceView` render data and 10 strictly alternating samples per variant:

| Workload | Baseline mean | This PR mean | Mean change | Baseline median | This PR median |
|---|---:|---:|---:|---:|---:|
| 50,000 completed-cache hits | 265.321 ms | 28.429 ms | -89.3% / 9.33× | 264.016 ms | 28.318 ms |
| 24 concurrent distinct keys | 47.965 ms | 47.314 ms | -1.4% (noise) | 47.200 ms | 47.367 ms |

Hot-hit paired mean saving was 236.892 ms (95% CI 234.031–239.753 ms). Updated distinct-key paired saving was 0.650 ms (95% CI -1.692 to 2.993 ms), so that workload has no measurable wall-time change after the safe subscriber-lifetime handling.

## Rendering and cache parity

Every measured sample preserved output signatures and upstream counts. Final WatchChess correctness also verified:

- synchronous first request is a miss and the repeat is a hit
- real async rendering remains cold miss → warm hit
- a temporary wrapper delivers delayed output after leaving scope
- an in-flight memory warning preserves the original observer while starting replacement work
- wrapper release cancels in-flight work
- 32 same-key waiters share exactly one upstream render
- cold, warm, persistent, and memory-warning-invalidated pixels match
- multi-value first/latest output behavior is preserved
- disk persistence and cache invalidation remain correct
- empty upstream completion retries and caches instead of poisoning the key

Weak-reference tests prove the renderer is released after both active-producer completion and cancellation; ReactiveSwift drops the intentional lifetime hold when that lifetime ends.

A pre-existing PNG disk-reload scale-metadata loss remains identical here: the same 88×88 pixels reload as 88 pt @1× instead of 44 pt @2×. PR #79 fixes that separately.

## Validation

- `swiftlint --config .swiftlint.yml --strict`
- full iOS simulator suite: 62 XCTest/Quick + 10 Swift Testing tests passed
- final WatchChess Release correctness suite passed against `1416481`
- 20/20 hot-hit and 20/20 updated distinct-key timing samples passed signature/count assertions