### PR TITLE
[Performance] Combine AsyncImageView optimizations

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: macos-26
     timeout-minutes: 30
     env:
       CI: true

--- a/AsyncImageView/AsyncImageLoader.swift
+++ b/AsyncImageView/AsyncImageLoader.swift
@@ -27,11 +27,9 @@ Renderer.RenderResult == PlaceholderRenderer.RenderResult {
         requestsSignal: Signal<Data?, Never>,
         renderer: Renderer,
         placeholderRenderer: PlaceholderRenderer?,
-        uiScheduler: ReactiveSwift.Scheduler,
-        imageCreationScheduler: ReactiveSwift.Scheduler
+        uiScheduler: ReactiveSwift.Scheduler
     ) -> Signal<Renderer.RenderResult?, Never> {
         return requestsSignal.skipRepeats(==)
-            .observe(on: imageCreationScheduler)
             .flatMap(.latest) { data -> SignalProducer<Renderer.RenderResult?, Never> in
                 let prefixSignal: SignalProducer<Renderer.RenderResult?, Never> = .init(value: nil)
 

--- a/AsyncImageView/AsyncImageView.swift
+++ b/AsyncImageView/AsyncImageView.swift
@@ -59,8 +59,7 @@ open class AsyncImageView<
 			requestsSignal: self.requestsSignal,
 			renderer: renderer,
 			placeholderRenderer: placeholderRenderer,
-			uiScheduler: uiScheduler,
-			imageCreationScheduler: imageCreationScheduler
+			uiScheduler: uiScheduler
 		)
 		.observeValues { [weak self] result in
 			self?.updateImage(result)

--- a/AsyncImageView/AsyncImageView.swift
+++ b/AsyncImageView/AsyncImageView.swift
@@ -77,13 +77,17 @@ open class AsyncImageView<
 
 	open override var frame: CGRect {
 		didSet {
-			self.requestNewImageIfReady()
+			if self.frame.size != oldValue.size {
+				self.requestNewImageIfReady()
+			}
 		}
 	}
 
 	open override var bounds: CGRect {
 		didSet {
-			self.requestNewImageIfReady()
+			if self.bounds.size != oldValue.size {
+				self.requestNewImageIfReady()
+			}
 		}
 	}
 

--- a/AsyncImageView/AsyncSwiftUIImageView.swift
+++ b/AsyncImageView/AsyncSwiftUIImageView.swift
@@ -60,10 +60,11 @@ Renderer.RenderResult == PlaceholderRenderer.RenderResult {
             self.imageView
 
             Color.clear
-                .modifier(SizeModifier())
-                .onPreferenceChange(ImageSizePreferenceKey.self) { imageSize in
-                    self.size = imageSize
-                }
+        }
+        .onGeometryChange(for: CGSize.self) { geometry in
+            geometry.size
+        } action: { imageSize in
+            self.size = imageSize
         }
         .onAppear {
             self.viewModel.start()
@@ -107,27 +108,6 @@ public extension AsyncSwiftUIImageView {
         view.data = data
 
         return view
-    }
-}
-
-private struct ImageSizePreferenceKey: PreferenceKey {
-    typealias Value = CGSize
-
-    static var defaultValue: CGSize = .zero
-
-    static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
-        value = nextValue()
-    }
-}
-
-private struct SizeModifier: ViewModifier {
-    func body(content: Content) -> some View {
-        content.background(
-            GeometryReader { geometry in
-                Color.clear
-                    .preference(key: ImageSizePreferenceKey.self, value: geometry.size)
-            }
-        )
     }
 }
 

--- a/AsyncImageView/AsyncSwiftUIImageView.swift
+++ b/AsyncImageView/AsyncSwiftUIImageView.swift
@@ -20,23 +20,82 @@ public struct AsyncSwiftUIImageView<
     Renderer.Error == Never,
     PlaceholderRenderer.Data == Data,
     PlaceholderRenderer.Error == Never,
-Renderer.RenderResult == PlaceholderRenderer.RenderResult {
+    Renderer.RenderResult == PlaceholderRenderer.RenderResult {
     private typealias ViewModel = AsyncSwiftUIImageViewModel<Data, ImageViewData, Renderer, PlaceholderRenderer>
 
-    @State private var viewModel: ViewModel
+    @State private var viewModelReference: LazyReference<ViewModel>
+
+    private var viewModel: ViewModel {
+        self.viewModelReference.value
+    }
+
+    public init(
+        renderer: Renderer,
+        placeholderRenderer: PlaceholderRenderer? = nil
+    ) {
+        self.init(
+            renderer: renderer,
+            placeholderRenderer: placeholderRenderer,
+            uiSchedulerFactory: { UIScheduler() },
+            imageCreationSchedulerFactory: { QueueScheduler() }
+        )
+    }
 
     public init(
         renderer: Renderer,
         placeholderRenderer: PlaceholderRenderer? = nil,
-        uiScheduler: ReactiveSwift.Scheduler = UIScheduler(),
-        imageCreationScheduler: ReactiveSwift.Scheduler = QueueScheduler()) {
-        _viewModel = State(
-            initialValue: ViewModel(
-                renderer: renderer,
-                placeholderRenderer: placeholderRenderer,
-                uiScheduler: uiScheduler,
-                imageCreationScheduler: imageCreationScheduler
-            )
+        uiScheduler: ReactiveSwift.Scheduler
+    ) {
+        self.init(
+            renderer: renderer,
+            placeholderRenderer: placeholderRenderer,
+            uiSchedulerFactory: { uiScheduler },
+            imageCreationSchedulerFactory: { QueueScheduler() }
+        )
+    }
+
+    public init(
+        renderer: Renderer,
+        placeholderRenderer: PlaceholderRenderer? = nil,
+        imageCreationScheduler: ReactiveSwift.Scheduler
+    ) {
+        self.init(
+            renderer: renderer,
+            placeholderRenderer: placeholderRenderer,
+            uiSchedulerFactory: { UIScheduler() },
+            imageCreationSchedulerFactory: { imageCreationScheduler }
+        )
+    }
+
+    public init(
+        renderer: Renderer,
+        placeholderRenderer: PlaceholderRenderer? = nil,
+        uiScheduler: ReactiveSwift.Scheduler,
+        imageCreationScheduler: ReactiveSwift.Scheduler
+    ) {
+        self.init(
+            renderer: renderer,
+            placeholderRenderer: placeholderRenderer,
+            uiSchedulerFactory: { uiScheduler },
+            imageCreationSchedulerFactory: { imageCreationScheduler }
+        )
+    }
+
+    internal init(
+        renderer: Renderer,
+        placeholderRenderer: PlaceholderRenderer?,
+        uiSchedulerFactory: @escaping () -> ReactiveSwift.Scheduler,
+        imageCreationSchedulerFactory: @escaping () -> ReactiveSwift.Scheduler
+    ) {
+        _viewModelReference = State(
+            initialValue: LazyReference {
+                ViewModel(
+                    renderer: renderer,
+                    placeholderRenderer: placeholderRenderer,
+                    uiScheduler: uiSchedulerFactory(),
+                    imageCreationScheduler: imageCreationSchedulerFactory()
+                )
+            }
         )
     }
 
@@ -99,6 +158,19 @@ Renderer.RenderResult == PlaceholderRenderer.RenderResult {
         }
 
         self.viewModel.requestImage(self.data, size: self.size)
+    }
+}
+
+private final class LazyReference<Value> {
+    private let factory: () -> Value
+    private lazy var storedValue = self.factory()
+
+    var value: Value {
+        self.storedValue
+    }
+
+    init(factory: @escaping () -> Value) {
+        self.factory = factory
     }
 }
 

--- a/AsyncImageView/AsyncSwiftUIImageView.swift
+++ b/AsyncImageView/AsyncSwiftUIImageView.swift
@@ -117,8 +117,6 @@ public struct AsyncSwiftUIImageView<
     public var body: some View {
         ZStack {
             self.imageView
-
-            Color.clear
         }
         .onGeometryChange(for: CGSize.self) { geometry in
             geometry.size

--- a/AsyncImageView/AsyncSwiftUIImageView.swift
+++ b/AsyncImageView/AsyncSwiftUIImageView.swift
@@ -158,8 +158,7 @@ private final class AsyncSwiftUIImageViewModel<
             requestsSignal: self.requestsSignal,
             renderer: self.renderer,
             placeholderRenderer: self.placeholderRenderer,
-            uiScheduler: self.uiScheduler,
-            imageCreationScheduler: self.imageCreationScheduler
+            uiScheduler: self.uiScheduler
         )
         .observeValues { [weak self] result in
             self?.renderResult = result

--- a/AsyncImageView/Caching.swift
+++ b/AsyncImageView/Caching.swift
@@ -97,6 +97,22 @@ public protocol NSDataConvertible {
 
 	/// Encodes the receiver in `NSData`. Returns `nil` if failed.
 	var data: Data? { get }
+
+	/// Creates an instance from its disk-cache representation.
+	static func valueFromCacheData(_ data: Data) -> Self?
+
+	/// Encodes the receiver for storage in `DiskCache`. Returns `nil` if failed.
+	var cacheData: Data? { get }
+}
+
+public extension NSDataConvertible {
+	static func valueFromCacheData(_ data: Data) -> Self? {
+		Self(data: data)
+	}
+
+	var cacheData: Data? {
+		self.data
+	}
 }
 
 /// Returns the directory where all `DiskCache` caches are stored
@@ -129,7 +145,7 @@ public final class DiskCache<K: DataFileType, V: NSDataConvertible>: CacheType {
 
 	public func valueForKey(_ key: K) -> V? {
 		return withLock { (try? Data(contentsOf: self.filePathForKey(key))) }
-			.flatMap(V.init)
+			.flatMap(V.valueFromCacheData)
 	}
 
 	public func setValue(_ value: V?, forKey key: K) {
@@ -138,7 +154,7 @@ public final class DiskCache<K: DataFileType, V: NSDataConvertible>: CacheType {
 		self.withLock {
 			self.guaranteeDirectoryExists(url.deletingLastPathComponent())
 
-			if let data = value.flatMap({ $0.data }) {
+			if let data = value.flatMap({ $0.cacheData }) {
 				// swiftlint:disable:next force_try
 				try! data.write(to: url, options: .atomicWrite)
 			} else if self.fileManager.fileExists(atPath: url.path) {

--- a/AsyncImageView/Extensions.swift
+++ b/AsyncImageView/Extensions.swift
@@ -14,6 +14,14 @@ extension UIImage: NSDataConvertible {
 	public var data: Data? {
 		return self.pngData()
 	}
+
+	public static func valueFromCacheData(_ data: Data) -> Self? {
+		CachedImageSerialization.image(from: data) as? Self
+	}
+
+	public var cacheData: Data? {
+		CachedImageSerialization.data(for: self)
+	}
 }
 
 extension ImageResult: NSDataConvertible {
@@ -30,6 +38,50 @@ extension ImageResult: NSDataConvertible {
 
 	public var data: Data? {
 		return self.image.data
+	}
+
+	public static func valueFromCacheData(_ data: Data) -> ImageResult? {
+		UIImage.valueFromCacheData(data).map { image in
+			ImageResult(image: image, cacheHit: false)
+		}
+	}
+
+	public var cacheData: Data? {
+		self.image.cacheData
+	}
+}
+
+private enum CachedImageSerialization {
+	private static let currentVersion = 1
+
+	private struct Payload: Codable {
+		let version: Int
+		let pngData: Data
+		let scale: Double
+	}
+
+	static func data(for image: UIImage) -> Data? {
+		guard let pngData = image.pngData() else { return nil }
+
+		let payload = Payload(
+			version: self.currentVersion,
+			pngData: pngData,
+			scale: Double(image.scale)
+		)
+		let encoder = PropertyListEncoder()
+		encoder.outputFormat = .binary
+
+		return try? encoder.encode(payload)
+	}
+
+	static func image(from data: Data) -> UIImage? {
+		guard let payload = try? PropertyListDecoder().decode(Payload.self, from: data),
+			payload.version == self.currentVersion,
+			payload.scale.isFinite,
+			payload.scale > 0,
+			let image = UIImage(data: payload.pngData, scale: CGFloat(payload.scale)) else { return nil }
+
+		return image
 	}
 }
 

--- a/AsyncImageView/Renderers/MulticastedRenderer.swift
+++ b/AsyncImageView/Renderers/MulticastedRenderer.swift
@@ -14,11 +14,29 @@ private final class InFlightImage {
 	let result: Property<ImageResult?>
 	let observer: Signal<ImageResult, Never>.Observer
 	let disposable = SerialDisposable()
+	private let hasStarted = Atomic(false)
 
 	init() {
 		let (signal, observer) = Signal<ImageResult, Never>.pipe()
 		self.result = Property(initial: nil, then: signal)
 		self.observer = observer
+	}
+
+	deinit {
+		self.disposable.dispose()
+	}
+
+	func startIfNeeded(_ action: () -> Void) {
+		let shouldStart = self.hasStarted.modify { hasStarted in
+			guard !hasStarted else { return false }
+			hasStarted = true
+
+			return true
+		}
+
+		if shouldStart {
+			action()
+		}
 	}
 }
 
@@ -28,7 +46,7 @@ private enum CachedImage {
 }
 
 private enum CachedImageLookup {
-	case rendering(InFlightImage, shouldStart: Bool)
+	case rendering(InFlightImage)
 	case completed(ImageResult)
 }
 
@@ -68,11 +86,7 @@ public final class MulticastedRenderer<
 		case let .completed(result):
 			return SignalProducer(value: result)
 
-		case let .rendering(entry, shouldStart):
-			if shouldStart {
-				self.startRendering(data, into: entry)
-			}
-
+		case let .rendering(entry):
 			return self.producer(for: data, entry: entry)
 		}
 	}
@@ -84,13 +98,13 @@ public final class MulticastedRenderer<
 				return .completed(result)
 
 			case let .rendering(entry, latest: nil):
-				return .rendering(entry, shouldStart: false)
+				return .rendering(entry)
 
 			case nil:
 				let entry = InFlightImage()
 				cache[data] = .rendering(entry, latest: nil)
 
-				return .rendering(entry, shouldStart: true)
+				return .rendering(entry)
 			}
 		}
 	}
@@ -117,8 +131,8 @@ public final class MulticastedRenderer<
 		)
 
 		guard result.shouldCache else {
-			entry.observer.send(value: cacheMiss)
 			self.remove(entry, for: data)
+			entry.observer.send(value: cacheMiss)
 
 			return
 		}
@@ -150,8 +164,13 @@ public final class MulticastedRenderer<
 	}
 
 	private func producer(for data: Data, entry: InFlightImage) -> SignalProducer<ImageResult, Never> {
-		return SignalProducer { [weak self, entry] observer, lifetime in
-			let cachedResult = self?.cache.withValue { cache -> ImageResult? in
+		return SignalProducer { [self, entry] observer, lifetime in
+			lifetime.observeEnded {
+				_ = self
+				_ = entry
+			}
+
+			let cachedResult = self.cache.withValue { cache -> ImageResult? in
 				switch cache[data] {
 				case let .completed(result), let .rendering(_, latest: result?):
 					return result
@@ -161,9 +180,17 @@ public final class MulticastedRenderer<
 				}
 			}
 
-			let producer = cachedResult.map(SignalProducer.init(value:))
-				?? entry.result.producer.compactMap { $0 }.take(first: 1)
-			lifetime += producer.start(observer)
+			if let cachedResult {
+				lifetime += SignalProducer(value: cachedResult).start(observer)
+			} else {
+				lifetime += entry.result.producer
+					.compactMap { $0 }
+					.take(first: 1)
+					.start(observer)
+				entry.startIfNeeded {
+					self.startRendering(data, into: entry)
+				}
+			}
 		}
 	}
 

--- a/AsyncImageView/Renderers/MulticastedRenderer.swift
+++ b/AsyncImageView/Renderers/MulticastedRenderer.swift
@@ -165,6 +165,8 @@ public final class MulticastedRenderer<
 
 	private func producer(for data: Data, entry: InFlightImage) -> SignalProducer<ImageResult, Never> {
 		return SignalProducer { [self, entry] observer, lifetime in
+			// Keep async callbacks deliverable after cache eviction or a temporary wrapper.
+			// `Lifetime` releases this action on completion or cancellation.
 			lifetime.observeEnded {
 				_ = self
 				_ = entry

--- a/AsyncImageView/Renderers/MulticastedRenderer.swift
+++ b/AsyncImageView/Renderers/MulticastedRenderer.swift
@@ -10,8 +10,27 @@ import UIKit
 
 import ReactiveSwift
 
-// The initial value is `nil`.
-private typealias ImageProperty = Property<ImageResult?>
+private final class InFlightImage {
+	let result: Property<ImageResult?>
+	let observer: Signal<ImageResult, Never>.Observer
+	let disposable = SerialDisposable()
+
+	init() {
+		let (signal, observer) = Signal<ImageResult, Never>.pipe()
+		self.result = Property(initial: nil, then: signal)
+		self.observer = observer
+	}
+}
+
+private enum CachedImage {
+	case rendering(InFlightImage, latest: ImageResult?)
+	case completed(ImageResult)
+}
+
+private enum CachedImageLookup {
+	case rendering(InFlightImage, shouldStart: Bool)
+	case completed(ImageResult)
+}
 
 /// `RendererType` decorator which guarantees that images for a given `RenderDataType`
 /// are only rendered once, and multicasted to every observer.
@@ -23,7 +42,7 @@ public final class MulticastedRenderer<
 	Renderer.Data == Data,
 	Renderer.Error == Never {
 	private let renderer: Renderer
-	private let cache: Atomic<[Data: ImageProperty]>
+	private let cache: Atomic<[Data: CachedImage]>
 
     #if !os(watchOS)
 	private let memoryWarningDisposable: Disposable
@@ -45,36 +64,111 @@ public final class MulticastedRenderer<
 	}
 
 	public func renderImageWithData(_ data: Data) -> SignalProducer<ImageResult, Never> {
-		let property = getPropertyForData(data)
+		switch self.lookup(for: data) {
+		case let .completed(result):
+			return SignalProducer(value: result)
 
-		return property.producer
-			.filter { $0 != nil } // Skip initial `nil` value.
-			.map { $0! }
-			.take(first: 1)
- 	}
+		case let .rendering(entry, shouldStart):
+			if shouldStart {
+				self.startRendering(data, into: entry)
+			}
 
-	private func getPropertyForData(_ data: Data) -> ImageProperty {
-		var result: ImageProperty!
+			return self.producer(for: data, entry: entry)
+		}
+	}
 
-		self.cache.modify { cache in
-			if let property = cache[data] {
-				result = property
-			} else {
-				result = ImageProperty(
-					initial: nil,
-					then: renderer.createProducerForRenderingData(data)
-						.map(Optional.init)
-				)
+	private func lookup(for data: Data) -> CachedImageLookup {
+		return self.cache.modify { cache in
+			switch cache[data] {
+			case let .completed(result), let .rendering(_, latest: result?):
+				return .completed(result)
 
-				cache[data] = result
+			case let .rendering(entry, latest: nil):
+				return .rendering(entry, shouldStart: false)
+
+			case nil:
+				let entry = InFlightImage()
+				cache[data] = .rendering(entry, latest: nil)
+
+				return .rendering(entry, shouldStart: true)
 			}
 		}
+	}
 
-		return result
+	private func startRendering(_ data: Data, into entry: InFlightImage) {
+		entry.disposable.inner = self.renderer
+			.renderImageWithData(data)
+			.start { [weak self, weak entry] event in
+				guard let self, let entry else { return }
+
+				if let result = event.value {
+					self.receive(result, for: data, entry: entry)
+				} else if event.isTerminating {
+					self.finishRendering(data, entry: entry)
+				}
+			}
+	}
+
+	private func receive(_ result: Renderer.RenderResult, for data: Data, entry: InFlightImage) {
+		let cacheMiss = ImageResult(
+			image: result.image,
+			cacheHit: false,
+			shouldCache: result.shouldCache
+		)
+
+		guard result.shouldCache else {
+			entry.observer.send(value: cacheMiss)
+			self.remove(entry, for: data)
+
+			return
+		}
+
+		let cacheHit = ImageResult(image: result.image, cacheHit: true, shouldCache: true)
+		self.cache.modify { cache in
+			guard case let .rendering(current, _) = cache[data], current === entry else { return }
+			cache[data] = .rendering(entry, latest: cacheHit)
+		}
+
+		entry.observer.send(value: cacheMiss)
+		entry.observer.send(value: cacheHit)
+	}
+
+	private func finishRendering(_ data: Data, entry: InFlightImage) {
+		self.cache.modify { cache in
+			guard case let .rendering(current, latest) = cache[data], current === entry else { return }
+
+			cache[data] = latest.map(CachedImage.completed)
+		}
+		entry.observer.sendCompleted()
+	}
+
+	private func remove(_ entry: InFlightImage, for data: Data) {
+		self.cache.modify { cache in
+			guard case let .rendering(current, _) = cache[data], current === entry else { return }
+			cache[data] = nil
+		}
+	}
+
+	private func producer(for data: Data, entry: InFlightImage) -> SignalProducer<ImageResult, Never> {
+		return SignalProducer { [weak self, entry] observer, lifetime in
+			let cachedResult = self?.cache.withValue { cache -> ImageResult? in
+				switch cache[data] {
+				case let .completed(result), let .rendering(_, latest: result?):
+					return result
+
+				case .rendering(_, latest: nil), nil:
+					return nil
+				}
+			}
+
+			let producer = cachedResult.map(SignalProducer.init(value:))
+				?? entry.result.producer.compactMap { $0 }.take(first: 1)
+			lifetime += producer.start(observer)
+		}
 	}
 
     #if !os(watchOS)
-	private static func clearCacheOnMemoryWarning(_ cache: Atomic<[Data: ImageProperty]>) -> Disposable {
+	private static func clearCacheOnMemoryWarning(_ cache: Atomic<[Data: CachedImage]>) -> Disposable {
 		return NotificationCenter.default
 			.reactive.notifications(forName: UIApplication.didReceiveMemoryWarningNotification, object: nil)
 			.observe(on: QueueScheduler())
@@ -89,17 +183,5 @@ extension RendererType where Error == Never {
 	/// Multicasts the results of this `RendererType`.
 	public func multicasted() -> MulticastedRenderer<Self, Self.Data> {
 		return MulticastedRenderer(renderer: self)
-	}
-}
-
-extension RendererType {
-	fileprivate func createProducerForRenderingData(_ data: Data) -> SignalProducer<ImageResult, Error> {
-		return self.renderImageWithData(data)
-			.flatMap(.concat) { result in
-				return SignalProducer([
-					ImageResult(image: result.image, cacheHit: false, shouldCache: result.shouldCache),
-					ImageResult(image: result.image, cacheHit: true, shouldCache: result.shouldCache)
-				])
-		}
 	}
 }

--- a/AsyncImageViewTests/AsyncImageSchedulerSpec.swift
+++ b/AsyncImageViewTests/AsyncImageSchedulerSpec.swift
@@ -1,0 +1,71 @@
+import Quick
+import Nimble
+import UIKit
+
+import ReactiveSwift
+
+import AsyncImageView
+
+class AsyncImageSchedulerSpec: QuickSpec {
+	override class func spec() {
+		describe("AsyncImageView scheduling") {
+			it("schedules image creation once per request") {
+				let imageCreationScheduler = CountingScheduler()
+				let renderer = SchedulerCheckingRenderer(scheduler: imageCreationScheduler)
+				let view = AsyncImageView<
+					TestRenderData,
+					TestData,
+					SchedulerCheckingRenderer,
+					SchedulerCheckingRenderer
+				>(
+					initialFrame: CGRect(origin: .zero, size: CGSize(width: 10, height: 10)),
+					renderer: renderer,
+					placeholderRenderer: nil,
+					uiScheduler: ImmediateScheduler(),
+					imageCreationScheduler: imageCreationScheduler
+				)
+				let window = UIWindow()
+				window.addSubview(view)
+				imageCreationScheduler.reset()
+
+				view.data = .a
+
+				expect(imageCreationScheduler.scheduleCount.value) == 1
+				expect(renderer.startedOnScheduler.value) == true
+			}
+		}
+	}
+}
+
+private final class CountingScheduler: Scheduler {
+	let scheduleCount = Atomic(0)
+	let isExecuting = Atomic(false)
+
+	func schedule(_ action: @escaping () -> Void) -> Disposable? {
+		self.scheduleCount.modify { $0 += 1 }
+		self.isExecuting.modify { $0 = true }
+		action()
+		self.isExecuting.modify { $0 = false }
+
+		return nil
+	}
+
+	func reset() {
+		self.scheduleCount.modify { $0 = 0 }
+	}
+}
+
+private final class SchedulerCheckingRenderer: RendererType {
+	let startedOnScheduler = Atomic(false)
+	private let scheduler: CountingScheduler
+
+	init(scheduler: CountingScheduler) {
+		self.scheduler = scheduler
+	}
+
+	func renderImageWithData(_ data: TestRenderData) -> SignalProducer<UIImage, Never> {
+		self.startedOnScheduler.modify { $0 = self.scheduler.isExecuting.value }
+
+		return SignalProducer(value: UIImage())
+	}
+}

--- a/AsyncImageViewTests/AsyncImageViewRequestSpec.swift
+++ b/AsyncImageViewTests/AsyncImageViewRequestSpec.swift
@@ -1,0 +1,84 @@
+import Quick
+import Nimble
+import UIKit
+
+import ReactiveSwift
+
+import AsyncImageView
+
+class AsyncImageViewRequestSpec: QuickSpec {
+	override class func spec() {
+		describe("AsyncImageView requests") {
+			var counter: Atomic<Int>!
+			var view: AsyncImageView<
+				RequestTestRenderData,
+				RequestTestViewData,
+				RequestTestRenderer,
+				RequestTestRenderer
+			>!
+			var window: UIWindow!
+
+			beforeEach {
+				counter = Atomic(0)
+				view = AsyncImageView<
+					RequestTestRenderData,
+					RequestTestViewData,
+					RequestTestRenderer,
+					RequestTestRenderer
+				>(
+					initialFrame: CGRect(origin: .zero, size: CGSize(width: 10, height: 10)),
+					renderer: RequestTestRenderer(),
+					placeholderRenderer: nil,
+					uiScheduler: ImmediateScheduler(),
+					imageCreationScheduler: ImmediateScheduler()
+				)
+				window = UIWindow()
+				window.addSubview(view)
+				view.data = RequestTestViewData(counter: counter)
+			}
+
+			it("does not create render data for frame origin changes") {
+				for offset in 1...10 {
+					view.frame.origin.x = CGFloat(offset)
+				}
+
+				expect(counter.value) == 1
+			}
+
+			it("does not create render data for bounds origin changes") {
+				for offset in 1...10 {
+					view.bounds.origin.x = CGFloat(offset)
+				}
+
+				expect(counter.value) == 1
+			}
+
+			it("creates render data for size changes") {
+				view.frame.size = CGSize(width: 20, height: 20)
+				view.bounds.size = CGSize(width: 30, height: 30)
+
+				expect(counter.value) == 3
+			}
+		}
+	}
+}
+
+private struct RequestTestViewData: ImageViewDataType {
+	let counter: Atomic<Int>
+
+	func renderDataWithSize(_ size: CGSize) -> RequestTestRenderData {
+		self.counter.modify { $0 += 1 }
+
+		return RequestTestRenderData(size: size)
+	}
+}
+
+private struct RequestTestRenderData: RenderDataType {
+	let size: CGSize
+}
+
+private final class RequestTestRenderer: RendererType {
+	func renderImageWithData(_ data: RequestTestRenderData) -> SignalProducer<UIImage, Never> {
+		return SignalProducer(value: UIImage())
+	}
+}

--- a/AsyncImageViewTests/AsyncSwiftUIImageViewSpec.swift
+++ b/AsyncImageViewTests/AsyncSwiftUIImageViewSpec.swift
@@ -1,0 +1,42 @@
+import Quick
+import Nimble
+import SwiftUI
+import UIKit
+
+import ReactiveSwift
+
+import AsyncImageView
+
+class AsyncSwiftUIImageViewSpec: QuickSpec {
+    override class func spec() {
+        describe("AsyncSwiftUIImageView") {
+            it("requests the full proposed size") {
+                let renderer = TestRenderer()
+                typealias ViewType = AsyncSwiftUIImageView<
+                    TestRenderData,
+                    TestData,
+                    TestRenderer,
+                    TestRenderer
+                >
+                let view = ViewType(
+                    renderer: renderer,
+                    placeholderRenderer: nil,
+                    uiScheduler: ImmediateScheduler(),
+                    imageCreationScheduler: ImmediateScheduler()
+                )
+                .data(.a)
+                .frame(width: 300, height: 100)
+                let viewController = UIHostingController(rootView: view)
+                let window = UIWindow(frame: CGRect(origin: .zero, size: CGSize(width: 300, height: 100)))
+                window.rootViewController = viewController
+                window.makeKeyAndVisible()
+                viewController.view.frame = window.bounds
+                viewController.view.layoutIfNeeded()
+
+                expect(renderer.renderedImages.value).toEventually(
+                    contain(TestRenderData(data: .a, size: window.bounds.size))
+                )
+            }
+        }
+    }
+}

--- a/AsyncImageViewTests/AsyncSwiftUIImageViewSpec.swift
+++ b/AsyncImageViewTests/AsyncSwiftUIImageViewSpec.swift
@@ -11,12 +11,12 @@ class AsyncSwiftUIImageViewSpec: QuickSpec {
     override class func spec() {
         describe("AsyncSwiftUIImageView") {
             it("requests the full proposed size") {
-                let renderer = TestRenderer()
+                let renderer = SquareImageRenderer()
                 typealias ViewType = AsyncSwiftUIImageView<
                     TestRenderData,
                     TestData,
-                    TestRenderer,
-                    TestRenderer
+                    SquareImageRenderer,
+                    SquareImageRenderer
                 >
                 let view = ViewType(
                     renderer: renderer,
@@ -33,10 +33,27 @@ class AsyncSwiftUIImageViewSpec: QuickSpec {
                 viewController.view.frame = window.bounds
                 viewController.view.layoutIfNeeded()
 
-                expect(renderer.renderedImages.value).toEventually(
-                    contain(TestRenderData(data: .a, size: window.bounds.size))
-                )
+                let expectedRequest = TestRenderData(data: .a, size: window.bounds.size)
+                expect(renderer.renderedImages.value).toEventually(equal([expectedRequest]))
+
+                RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.1))
+                viewController.view.layoutIfNeeded()
+
+                expect(renderer.renderedImages.value) == [expectedRequest]
             }
         }
+    }
+}
+
+private final class SquareImageRenderer: RendererType {
+    let renderedImages = Atomic<[TestRenderData]>([])
+
+    func renderImageWithData(_ data: TestRenderData) -> SignalProducer<UIImage, Never> {
+        TestRenderer.rendererForSize(CGSize(width: 100, height: 100), scale: 1)
+            .asyncRenderer(ImmediateScheduler())
+            .renderImageWithData(data)
+            .on(started: {
+                self.renderedImages.modify { $0.append(data) }
+            })
     }
 }

--- a/AsyncImageViewTests/AsyncSwiftUIImageViewStateSpec.swift
+++ b/AsyncImageViewTests/AsyncSwiftUIImageViewStateSpec.swift
@@ -1,0 +1,110 @@
+import Quick
+import Nimble
+import SwiftUI
+import UIKit
+
+import ReactiveSwift
+
+@testable import AsyncImageView
+
+class AsyncSwiftUIImageViewStateSpec: QuickSpec {
+    override class func spec() {
+        describe("AsyncSwiftUIImageView state") {
+            it("preserves every scheduler initializer combination") {
+                let renderer = StateTestRenderer()
+
+                _ = StateTestImageView(renderer: renderer)
+                _ = StateTestImageView(renderer: renderer, uiScheduler: ImmediateScheduler())
+                _ = StateTestImageView(renderer: renderer, imageCreationScheduler: ImmediateScheduler())
+                _ = StateTestImageView(
+                    renderer: renderer,
+                    uiScheduler: ImmediateScheduler(),
+                    imageCreationScheduler: ImmediateScheduler()
+                )
+            }
+
+            it("creates its retained schedulers only once across parent updates") {
+                let schedulerFactory = SchedulerFactory()
+                let renderer = StateTestRenderer()
+                let initialView = StateTestContainer(
+                    generation: 0,
+                    renderer: renderer,
+                    schedulerFactory: schedulerFactory
+                )
+                let viewController = UIHostingController(rootView: initialView)
+                let window = UIWindow(frame: CGRect(origin: .zero, size: CGSize(width: 100, height: 100)))
+                window.rootViewController = viewController
+                window.makeKeyAndVisible()
+                viewController.view.frame = window.bounds
+                viewController.view.layoutIfNeeded()
+
+                for generation in 1...100 {
+                    viewController.rootView = StateTestContainer(
+                        generation: generation,
+                        renderer: renderer,
+                        schedulerFactory: schedulerFactory
+                    )
+                    viewController.view.layoutIfNeeded()
+                }
+
+                expect(schedulerFactory.uiSchedulerCount.value) == 1
+                expect(schedulerFactory.imageSchedulerCount.value) == 1
+            }
+        }
+    }
+}
+
+private struct StateTestContainer: View {
+    let generation: Int
+    let renderer: StateTestRenderer
+    let schedulerFactory: SchedulerFactory
+
+    var body: some View {
+        StateTestImageView(
+            renderer: self.renderer,
+            placeholderRenderer: nil,
+            uiSchedulerFactory: self.schedulerFactory.makeUIScheduler,
+            imageCreationSchedulerFactory: self.schedulerFactory.makeImageScheduler
+        )
+        .frame(width: 100, height: 100)
+        .accessibilityIdentifier("generation-\(self.generation)")
+    }
+}
+
+private typealias StateTestImageView = AsyncSwiftUIImageView<
+    StateTestRenderData,
+    StateTestViewData,
+    StateTestRenderer,
+    StateTestRenderer
+>
+
+private final class SchedulerFactory {
+    let uiSchedulerCount = Atomic(0)
+    let imageSchedulerCount = Atomic(0)
+
+    func makeUIScheduler() -> ReactiveSwift.Scheduler {
+        self.uiSchedulerCount.modify { $0 += 1 }
+        return ImmediateScheduler()
+    }
+
+    func makeImageScheduler() -> ReactiveSwift.Scheduler {
+        self.imageSchedulerCount.modify { $0 += 1 }
+        return ImmediateScheduler()
+    }
+}
+
+private struct StateTestViewData: ImageViewDataType {
+    func renderDataWithSize(_ size: CGSize) -> StateTestRenderData {
+        StateTestRenderData(size: size)
+    }
+}
+
+private struct StateTestRenderData: RenderDataType {
+    let size: CGSize
+}
+
+private final class StateTestRenderer: RendererType {
+    func renderImageWithData(_ data: StateTestRenderData) -> SignalProducer<UIImage, Never> {
+        SignalProducer(value: UIImage())
+    }
+}

--- a/AsyncImageViewTests/DiskCacheImageScaleTests.swift
+++ b/AsyncImageViewTests/DiskCacheImageScaleTests.swift
@@ -1,0 +1,105 @@
+import Foundation
+import Testing
+import UIKit
+
+import ReactiveSwift
+
+@testable import AsyncImageView
+
+@Suite
+struct DiskCacheImageScaleTests {
+	@Test
+	func preservesImageScaleAndDimensions() throws {
+		let cache = DiskCache<ImageCacheKey, UIImage>(rootDirectory: temporaryDirectory())
+		let image = makeImage(size: CGSize(width: 44, height: 44), scale: 2)
+		let key = ImageCacheKey(uniqueFilename: "image", size: image.size)
+
+		cache.setValue(image, forKey: key)
+		let restored = try #require(cache.valueForKey(key))
+
+		#expect(restored.size == image.size)
+		#expect(restored.scale == image.scale)
+		#expect(restored.cgImage?.width == image.cgImage?.width)
+		#expect(restored.cgImage?.height == image.cgImage?.height)
+	}
+
+	@Test
+	func preservesScaleThroughACachedRendererHit() throws {
+		let cache = DiskCache<ImageCacheKey, ImageResult>(rootDirectory: temporaryDirectory())
+		let image = makeImage(size: CGSize(width: 52, height: 52), scale: 3)
+		let key = ImageCacheKey(uniqueFilename: "result", size: image.size)
+		let source = ScaleImageRenderer(image: image)
+		let renderer = source.withCache(cache)
+
+		let rendered = try #require(renderer.renderImageWithData(key).single()?.get())
+		let restored = try #require(renderer.renderImageWithData(key).single()?.get())
+
+		#expect(source.renderCount == 1)
+		#expect(rendered.cacheHit == false)
+		#expect(restored.cacheHit == true)
+		#expect(restored.image.size == image.size)
+		#expect(restored.image.scale == image.scale)
+		#expect(restored.image.cgImage?.width == image.cgImage?.width)
+		#expect(restored.image.cgImage?.height == image.cgImage?.height)
+	}
+
+	@Test
+	func regeneratesLegacyRawPNGEntries() throws {
+		let directory = temporaryDirectory()
+		let cache = DiskCache<ImageCacheKey, ImageResult>(rootDirectory: directory)
+		let key = ImageCacheKey(uniqueFilename: "legacy", size: CGSize(width: 44, height: 44))
+		let image = makeImage(size: CGSize(width: 44, height: 44), scale: 2)
+		let source = ScaleImageRenderer(image: image)
+		let renderer = source.withCache(cache)
+		let data = try #require(image.pngData())
+		try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+		try data.write(to: directory.appendingPathComponent(key.uniqueFilename))
+
+		let regenerated = try #require(renderer.renderImageWithData(key).single()?.get())
+		let cached = try #require(renderer.renderImageWithData(key).single()?.get())
+
+		#expect(source.renderCount == 1)
+		#expect(regenerated.cacheHit == false)
+		#expect(cached.cacheHit == true)
+		#expect(cached.image.size == image.size)
+		#expect(cached.image.scale == image.scale)
+	}
+
+	private func temporaryDirectory() -> URL {
+		URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+			.appendingPathComponent(ProcessInfo.processInfo.globallyUniqueString, isDirectory: true)
+	}
+
+	private func makeImage(size: CGSize, scale: CGFloat) -> UIImage {
+		let format = UIGraphicsImageRendererFormat()
+		format.scale = scale
+
+		return UIGraphicsImageRenderer(size: size, format: format).image { context in
+			context.cgContext.setFillColor(UIColor.red.cgColor)
+			context.cgContext.fill(CGRect(origin: .zero, size: size))
+		}
+	}
+}
+
+private struct ImageCacheKey: DataFileType {
+	let uniqueFilename: String
+	let size: CGSize
+	let subdirectory: String? = nil
+}
+
+extension ImageCacheKey: RenderDataType {}
+
+private final class ScaleImageRenderer: RendererType {
+	private let image: UIImage
+	private(set) var renderCount = 0
+
+	init(image: UIImage) {
+		self.image = image
+	}
+
+	func renderImageWithData(_ data: ImageCacheKey) -> SignalProducer<ImageResult, Never> {
+		self.renderCount += 1
+
+		return SignalProducer(value: ImageResult(image: self.image, cacheHit: false))
+	}
+}

--- a/AsyncImageViewTests/MulticastedRendererSpec.swift
+++ b/AsyncImageViewTests/MulticastedRendererSpec.swift
@@ -127,15 +127,14 @@ class MulticastedRendererSpec: QuickSpec {
 					expect(getCacheHitValue()) == false
 				}
 
-				it("is a cache hit the second time the producer is fetched") {
-					let producer = getProducerForData(data, size)
+				it("is a cache hit after the initial producer completes") {
+					var initialResult: ImageResult?
+					getProducerForData(data, size).startWithValues { initialResult = $0 }
 					scheduler.advance(by: interval)
+					expect(initialResult).toEventuallyNot(beNil())
 
-					var result: ImageResult?
-					producer.startWithValues { result = $0 }
-
-					expect(result).toEventuallyNot(beNil())
-					expect(result?.cacheHit) == true
+					expect(initialResult?.cacheHit) == false
+					expect(getImageForData(data, size)?.cacheHit) == true
 				}
 			}
 		}

--- a/AsyncImageViewTests/MulticastedRendererTests.swift
+++ b/AsyncImageViewTests/MulticastedRendererTests.swift
@@ -176,14 +176,39 @@ struct MulticastedRendererTests {
 	func cancelsInFlightWorkWhenTheRendererIsReleased() {
 		let source = CancellableRenderer()
 		var renderer: MulticastedRenderer<CancellableRenderer, MulticastRenderData>? = source.multicasted()
+		weak var weakRenderer = renderer
 		let disposable = renderer?.renderImageWithData(MulticastRenderData(identifier: 1)).start()
 
 		#expect(source.started.value == true)
 		#expect(source.cancelled.value == false)
-		disposable?.dispose()
 		renderer = nil
+		#expect(weakRenderer != nil)
+		disposable?.dispose()
 
 		#expect(source.cancelled.value == true)
+		#expect(weakRenderer == nil)
+	}
+
+	@Test
+	func releasesTheRendererWhenAnActiveProducerCompletes() throws {
+		let image = makeImage()
+		let source = MultiValueRenderer()
+		var renderer: MulticastedRenderer<MultiValueRenderer, MulticastRenderData>? = source.multicasted()
+		weak var weakRenderer = renderer
+		var result: ImageResult?
+		let disposable = renderer?
+			.renderImageWithData(MulticastRenderData(identifier: 1))
+			.startWithValues { result = $0 }
+		defer { disposable?.dispose() }
+
+		renderer = nil
+		#expect(weakRenderer != nil)
+		source.observer.send(value: image)
+
+		let rendered = try #require(result)
+		#expect(rendered.image === image)
+		#expect(weakRenderer == nil)
+		source.observer.sendCompleted()
 	}
 
 	@Test

--- a/AsyncImageViewTests/MulticastedRendererTests.swift
+++ b/AsyncImageViewTests/MulticastedRendererTests.swift
@@ -1,0 +1,222 @@
+//
+//  MulticastedRendererTests.swift
+//  AsyncImageViewTests
+//
+//  Created by Nacho Soto on 7/11/26.
+//  Copyright © 2026 Nacho Soto. All rights reserved.
+//
+
+import Foundation
+import Testing
+import UIKit
+
+import ReactiveSwift
+
+@testable import AsyncImageView
+
+@Suite
+struct MulticastedRendererTests {
+	@Test
+	func rendersDifferentKeysConcurrently() {
+		let source = BlockingRenderer()
+		let renderer = UncheckedSendable(source.multicasted())
+		let group = DispatchGroup()
+		let queue = DispatchQueue(label: #function, attributes: .concurrent)
+
+		for identifier in 0..<2 {
+			group.enter()
+			queue.async {
+				let data = MulticastRenderData(identifier: identifier)
+				_ = renderer.value.renderImageWithData(data).single()
+				group.leave()
+			}
+		}
+
+		let firstStarted = source.started.wait(timeout: .now() + 2)
+		let secondStarted = source.started.wait(timeout: .now() + 2)
+		source.release.signal()
+		source.release.signal()
+		let completed = group.wait(timeout: .now() + 2)
+
+		#expect(firstStarted == .success)
+		#expect(secondStarted == .success)
+		#expect(completed == .success)
+	}
+
+	@Test
+	func preservesTheLatestValueFromAMultiValueRenderer() throws {
+		let firstImage = makeImage(size: CGSize(width: 16, height: 16))
+		let secondImage = makeImage(size: CGSize(width: 32, height: 32))
+		let source = MultiValueRenderer()
+		let renderer = source.multicasted()
+		let data = MulticastRenderData(identifier: 1)
+		var initial: ImageResult?
+		let disposable = renderer.renderImageWithData(data).startWithValues { initial = $0 }
+		defer { disposable.dispose() }
+
+		source.observer.send(value: firstImage)
+		let firstHit = try #require(renderer.renderImageWithData(data).single()?.get())
+
+		source.observer.send(value: secondImage)
+		let secondHit = try #require(renderer.renderImageWithData(data).single()?.get())
+
+		source.observer.sendCompleted()
+		let completedHit = try #require(renderer.renderImageWithData(data).single()?.get())
+
+		#expect(source.renderCount == 1)
+		#expect(initial?.image === firstImage)
+		#expect(initial?.cacheHit == false)
+		#expect(firstHit.image === firstImage)
+		#expect(firstHit.cacheHit == true)
+		#expect(secondHit.image === secondImage)
+		#expect(secondHit.cacheHit == true)
+		#expect(completedHit.image === secondImage)
+		#expect(completedHit.cacheHit == true)
+	}
+
+	@Test
+	func sharesOneUpstreamRenderBetweenConcurrentWaiters() throws {
+		let image = makeImage()
+		let source = MultiValueRenderer()
+		let renderer = source.multicasted()
+		let data = MulticastRenderData(identifier: 1)
+		let firstProducer = renderer.renderImageWithData(data)
+		let secondProducer = renderer.renderImageWithData(data)
+		var first: ImageResult?
+		var second: ImageResult?
+		let firstDisposable = firstProducer.startWithValues { first = $0 }
+		let secondDisposable = secondProducer.startWithValues { second = $0 }
+		defer {
+			firstDisposable.dispose()
+			secondDisposable.dispose()
+		}
+
+		source.observer.send(value: image)
+		source.observer.sendCompleted()
+
+		let firstResult = try #require(first)
+		let secondResult = try #require(second)
+		#expect(source.renderCount == 1)
+		#expect(firstResult.image === image)
+		#expect(secondResult.image === image)
+		#expect(firstResult.cacheHit == false)
+		#expect(secondResult.cacheHit == false)
+	}
+
+	@Test
+	func retriesAfterANonCacheableResult() throws {
+		let source = RecoveringRenderer()
+		let renderer = source.multicasted()
+		let data = MulticastRenderData(identifier: 1)
+
+		let failed = try #require(renderer.renderImageWithData(data).single()?.get())
+		let recovered = try #require(renderer.renderImageWithData(data).single()?.get())
+		let cached = try #require(renderer.renderImageWithData(data).single()?.get())
+
+		#expect(source.renderCount == 2)
+		#expect(failed.cacheHit == false)
+		#expect(failed.shouldCache == false)
+		#expect(recovered.shouldCache == true)
+		#expect(cached.cacheHit == true)
+	}
+
+	@Test
+	func retriesAfterTheUpstreamCompletesWithoutAValue() throws {
+		let source = EmptyThenValueRenderer()
+		let renderer = source.multicasted()
+		let data = MulticastRenderData(identifier: 1)
+
+		let empty = renderer.renderImageWithData(data).single()
+		let recovered = try #require(renderer.renderImageWithData(data).single()?.get())
+		let cached = try #require(renderer.renderImageWithData(data).single()?.get())
+
+		#expect(empty == nil)
+		#expect(source.renderCount == 2)
+		#expect(recovered.image === source.image)
+		#expect(cached.image === source.image)
+		#expect(cached.cacheHit == true)
+	}
+}
+
+private struct MulticastRenderData: RenderDataType, Sendable {
+	let identifier: Int
+	let size = CGSize(width: 8, height: 8)
+}
+
+private struct UncheckedSendable<Value>: @unchecked Sendable {
+	let value: Value
+
+	init(_ value: Value) {
+		self.value = value
+	}
+}
+
+private final class BlockingRenderer: RendererType, @unchecked Sendable {
+	let started = DispatchSemaphore(value: 0)
+	let release = DispatchSemaphore(value: 0)
+
+	private let image = makeImage()
+
+	func renderImageWithData(_ data: MulticastRenderData) -> SignalProducer<UIImage, Never> {
+		return SignalProducer { [image = self.image, release = self.release, started = self.started] observer, lifetime in
+			started.signal()
+			release.wait()
+
+			guard !lifetime.hasEnded else { return }
+
+			observer.send(value: image)
+			observer.sendCompleted()
+		}
+	}
+}
+
+private final class MultiValueRenderer: RendererType {
+	let signal: Signal<UIImage, Never>
+	let observer: Signal<UIImage, Never>.Observer
+	private(set) var renderCount = 0
+
+	init() {
+		(self.signal, self.observer) = Signal.pipe()
+	}
+
+	func renderImageWithData(_ data: MulticastRenderData) -> SignalProducer<UIImage, Never> {
+		self.renderCount += 1
+
+		return self.signal.producer
+	}
+}
+
+private final class RecoveringRenderer: RendererType {
+	private let image = makeImage()
+	private let scheduler = QueueScheduler(name: "MulticastedRendererTests.RecoveringRenderer")
+	private(set) var renderCount = 0
+
+	func renderImageWithData(_ data: MulticastRenderData) -> SignalProducer<ImageResult, Never> {
+		self.renderCount += 1
+		let result = ImageResult(
+			image: self.image,
+			cacheHit: false,
+			shouldCache: self.renderCount > 1
+		)
+
+		return SignalProducer(value: result)
+			.start(on: self.scheduler)
+	}
+}
+
+private final class EmptyThenValueRenderer: RendererType {
+	let image = makeImage()
+	private(set) var renderCount = 0
+
+	func renderImageWithData(_ data: MulticastRenderData) -> SignalProducer<UIImage, Never> {
+		self.renderCount += 1
+
+		return self.renderCount == 1
+			? SignalProducer.empty
+			: SignalProducer(value: self.image)
+	}
+}
+
+private func makeImage(size: CGSize = CGSize(width: 8, height: 8)) -> UIImage {
+	return UIGraphicsImageRenderer(size: size).image { _ in }
+}

--- a/AsyncImageViewTests/MulticastedRendererTests.swift
+++ b/AsyncImageViewTests/MulticastedRendererTests.swift
@@ -14,7 +14,7 @@ import ReactiveSwift
 
 @testable import AsyncImageView
 
-@Suite
+@Suite(.serialized)
 struct MulticastedRendererTests {
 	@Test
 	func rendersDifferentKeysConcurrently() {
@@ -75,6 +75,22 @@ struct MulticastedRendererTests {
 	}
 
 	@Test
+	func preservesTheInitialCacheMissFromASynchronousRenderer() throws {
+		let source = SynchronousRenderer()
+		let renderer = source.multicasted()
+		let data = MulticastRenderData(identifier: 1)
+
+		let initial = try #require(renderer.renderImageWithData(data).single()?.get())
+		let cached = try #require(renderer.renderImageWithData(data).single()?.get())
+
+		#expect(source.renderCount == 1)
+		#expect(initial.image === source.image)
+		#expect(initial.cacheHit == false)
+		#expect(cached.image === source.image)
+		#expect(cached.cacheHit == true)
+	}
+
+	@Test
 	func sharesOneUpstreamRenderBetweenConcurrentWaiters() throws {
 		let image = makeImage()
 		let source = MultiValueRenderer()
@@ -101,6 +117,73 @@ struct MulticastedRendererTests {
 		#expect(secondResult.image === image)
 		#expect(firstResult.cacheHit == false)
 		#expect(secondResult.cacheHit == false)
+	}
+
+	@Test
+	func producerOutlivesATemporaryMulticastedRenderer() throws {
+		let image = makeImage()
+		let source = MultiValueRenderer()
+		let data = MulticastRenderData(identifier: 1)
+		let producer = source.multicasted().renderImageWithData(data)
+		var result: ImageResult?
+		let disposable = producer.startWithValues { result = $0 }
+		defer { disposable.dispose() }
+
+		source.observer.send(value: image)
+		source.observer.sendCompleted()
+
+		let rendered = try #require(result)
+		#expect(source.renderCount == 1)
+		#expect(rendered.image === image)
+		#expect(rendered.cacheHit == false)
+	}
+
+	@Test
+	func preservesInFlightDeliveryAcrossAMemoryWarning() throws {
+		let image = makeImage()
+		let source = MultiValueRenderer()
+		let renderer = source.multicasted()
+		let data = MulticastRenderData(identifier: 1)
+		var first: ImageResult?
+		let firstDisposable = renderer.renderImageWithData(data).startWithValues { first = $0 }
+		var secondDisposable: Disposable?
+		defer {
+			firstDisposable.dispose()
+			secondDisposable?.dispose()
+		}
+
+		#expect(source.renderCount == 1)
+		NotificationCenter.default.post(name: UIApplication.didReceiveMemoryWarningNotification, object: nil)
+
+		for _ in 0..<100 where source.renderCount < 2 {
+			secondDisposable?.dispose()
+			secondDisposable = renderer.renderImageWithData(data).start()
+			if source.renderCount < 2 {
+				Thread.sleep(forTimeInterval: 0.01)
+			}
+		}
+
+		#expect(source.renderCount == 2)
+		source.observer.send(value: image)
+		source.observer.sendCompleted()
+
+		let rendered = try #require(first)
+		#expect(rendered.image === image)
+		#expect(rendered.cacheHit == false)
+	}
+
+	@Test
+	func cancelsInFlightWorkWhenTheRendererIsReleased() {
+		let source = CancellableRenderer()
+		var renderer: MulticastedRenderer<CancellableRenderer, MulticastRenderData>? = source.multicasted()
+		let disposable = renderer?.renderImageWithData(MulticastRenderData(identifier: 1)).start()
+
+		#expect(source.started.value == true)
+		#expect(source.cancelled.value == false)
+		disposable?.dispose()
+		renderer = nil
+
+		#expect(source.cancelled.value == true)
 	}
 
 	@Test
@@ -183,6 +266,31 @@ private final class MultiValueRenderer: RendererType {
 		self.renderCount += 1
 
 		return self.signal.producer
+	}
+}
+
+private final class SynchronousRenderer: RendererType {
+	let image = makeImage()
+	private(set) var renderCount = 0
+
+	func renderImageWithData(_ data: MulticastRenderData) -> SignalProducer<UIImage, Never> {
+		self.renderCount += 1
+
+		return SignalProducer(value: self.image)
+	}
+}
+
+private final class CancellableRenderer: RendererType {
+	let started = Atomic(false)
+	let cancelled = Atomic(false)
+
+	func renderImageWithData(_ data: MulticastRenderData) -> SignalProducer<UIImage, Never> {
+		return SignalProducer { [cancelled = self.cancelled, started = self.started] _, lifetime in
+			started.modify { $0 = true }
+			lifetime.observeEnded {
+				cancelled.modify { $0 = true }
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

This branch combines the independently reviewed changes from:

- #77 — skip unchanged UIKit image sizes
- #78 — streamline SwiftUI geometry observation
- #79 — preserve `UIImage.scale` in the disk cache
- #80 — remove the redundant image-scheduler hop
- #81 — lazily initialize SwiftUI image state
- #82 — reduce multicast contention while preserving subscription semantics

## Component benchmarks

| Change | WatchChess workload | Result |
|---|---|---:|
| UIKit unchanged-size guard (#77) | 128,000 origin-only mutations | **-32.24% mean**, scheduler calls 128,000 → 0 |
| SwiftUI geometry (#78) | 100 real cells × 80 relayouts | **-2.86% mean**, 95% CI for saving 9.053–45.532 ms |
| Scheduler hop (#80) | 96 cold + 96 repeated requests | scheduler operations **-50%**; wall time neutral |
| Lazy SwiftUI state (#81) | 20,000 body reconstructions | **-4.44% mean**, 12/12 paired wins |
| Multicast completed hits (#82) | 50,000 real `PieceView` hits | **-89.3% / 9.33× faster** |
| Multicast distinct keys (#82) | 24 concurrent keys | neutral: -1.4% mean, 95% CI spans zero |

## Combined WatchChess benchmark

Release WatchChess, iPhone 17 Pro Max / iOS 26.5 simulators, 10 samples per variant and flow. Negative CPU/hitch changes are improvements.

### CPU

| Flow | CPU time, baseline → combined | Change (paired-bootstrap 95% CI) | Mean one-core-equivalent CPU |
|---|---:|---:|---:|
| Tournament-list scrolling | 2.230 → 2.264 s | +1.54% (-2.79% to +6.09%): neutral | 12.01% → 12.07% |
| Rounds scrolling | 1.059 → 1.024 s | **-3.25% (-5.55% to -1.27%)** | 13.03% → 12.79% |
| Open game | 0.452 → 0.439 s | **-2.89% (-5.36% to -0.12%)** | **13.47% → 13.11%** (-2.63%; CI -4.37% to -0.87%) |

### FPS and hitches

`FPS` below is a main-run-loop `CADisplayLink` callback proxy over the exact UI-action window, not compositor presentation FPS.

| Flow | FPS, baseline → combined | FPS change (95% CI) | Hitches/min, baseline → combined | Hitch change (95% CI) |
|---|---:|---:|---:|---:|
| Tournament-list scrolling | 58.93 → 59.00 | +0.12% (-0.20% to +0.48%): neutral | 40.67 → 37.39 | -8.06% (-29.75% to +14.24%): neutral |
| Rounds scrolling | 58.53 → 58.98 | **+0.77% (+0.13% to +1.39%)** | 63.24 → 51.68 | -18.28% (-35.36% to +5.33%): trend, CI spans zero |
| Open game | 54.14 → 54.07 | -0.14% (-1.20% to +0.91%): neutral | 131.04 → 145.44 | +10.99% (-5.26% to +29.68%): neutral |

Missed-refresh rates were also neutral for tournaments (-3.62%, CI -21.79% to +14.17%) and game (+2.99%, CI -5.93% to +13.06%). Rounds trended lower (-26.69%, CI -47.25% to +4.29%).

## Methodology and controls

- two-pass, pass-outer crossover: pass 1 baseline on simulator A then candidate on B; pass 2 candidate on A then baseline on B
- five measurements per pass, variant, and flow; 10 total per variant/flow
- engine analysis forced off (`currentEngineStrength = 1`) and validated inside every app launch/report
- exact 24-entry real API fixture in cache-only mode; any cache miss failed the run
- identical 147-path warm AsyncImageView cache coverage per variant
- exact AsyncImageView path/hash/mtime validation before sample 1 and after every five-sample block
- API path/size/hash validation before and after every block
- arithmetic-mean CPU headline; duration-weighted ratio-of-sums FPS/hitch rates
- deterministic 100,000-resample, pass-stratified paired bootstrap confidence intervals
- symmetric full cache hashing before each measured block; these are deliberately warm-cache measurements
- hitches: clipped display-link interval at least 1.5× its target refresh period

All earlier measurements with uncontrolled engine state or unequal cache warmness were quarantined and excluded.

## Rendering and cache regression checks

- cold game and rounds screenshots were pixel-identical; cold tournament app content was pixel-identical outside dynamic system chrome
- all four pass-1 seed/verify tournament screenshots were pixel-identical across the 1320×2590 app region; the only difference was 5,708 pixels in the translucent system search-field blur
- six gated 8 FPS recordings covered tournament scrolling, rounds scrolling, and opening a game for both variants
- manual contact-sheet review found no blank flashes, stale substitutions, missing portraits, or persistent placeholders; both game recordings showed the same normal transition placeholders and matching fully rendered end states
- all six recordings passed pre/post AsyncImageView and API cache audits
- baseline and candidate kept identical 147 relative cache paths; each variant's hashes and mtimes remained stable

The different cache bytes between variants are intentional: #79 stores image scale in a versioned envelope. Legacy raw-PNG entries become one normal miss and regenerate in the corrected format. Existing remote images may therefore re-download once; offline users can temporarily miss legacy cached images until connectivity returns.

## #79 and #82 semantics

#79 and the [#82 synchronous-subscriber review finding](https://github.com/NachoSoto/AsyncImageView/pull/82#discussion_r3564848476) are different fixes, and both are included:

- #79 fixes PNG disk-cache scale metadata.
- #82 attaches the first subscriber before starting synchronous upstream work, preserving first-request miss / repeat-request hit semantics.

#82's `lifetime.observeEnded` intentionally holds the wrapper and in-flight entry only until producer completion or cancellation. Weak-reference tests verify release after both paths, while cancellation still disposes upstream work; no retain cycle or leak was observed.

## Validation

- `swiftlint --config .swiftlint.yml --strict`: 0 violations
- full iOS simulator suite: 69 XCTest/Quick + 13 Swift Testing tests = **82 passed**
- focused multicast concurrency, synchronous, retry, memory-warning, cancellation, and weak-lifetime coverage
- WatchChess Release cache preflights, 60 CPU samples, 60 frame reports, and six visual recordings passed their evidence checks
- CI updated to macOS 26 / Xcode 26.5
