### PR TITLE
[Build] Configure Swift 6 language mode

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,10 @@ let package = Package(
         .target(
             name: "AsyncImageView",
             dependencies: ["ReactiveSwift"],
-            path: "AsyncImageView"
+            path: "AsyncImageView",
+            swiftSettings: [
+                .unsafeFlags(["-disable-dynamic-actor-isolation"])
+            ]
         ),
         .testTarget(
             name: "AsyncImageViewTests",
@@ -30,8 +33,11 @@ let package = Package(
                 "Quick",
                 "Nimble"
             ],
-            path: "AsyncImageViewTests"
+            path: "AsyncImageViewTests",
+            swiftSettings: [
+                .unsafeFlags(["-disable-dynamic-actor-isolation"])
+            ]
         )
     ],
-    swiftLanguageVersions: [.v5]
+    swiftLanguageModes: [.v6]
 )


### PR DESCRIPTION
## Scope

This is part 1 of a four-PR dependency chain. It changes only package configuration:

- compile the package in Swift 6 language mode
- pass `-disable-dynamic-actor-isolation` to the library and test targets

## Dependency chain

1. This PR: package configuration
2. Production concurrency correctness (bases on this PR)
3. Production concurrency escape hatches (bases on PR 2)
4. Test-only Swift 6 migrations and cleanup (bases on PR 3)

Do not merge this PR independently; the follow-up PRs complete the Swift 6 migration.

## Validation

- `swift package dump-package` confirms Swift 6 and the compiler flag on both targets
- `swiftlint --config .swiftlint.yml --strict`