### PR TITLE
[Concurrency] Define Swift 6 UI-rendering boundaries

### DIFF
--- a/AsyncImageView/Renderers/ImageInflaterRenderer.swift
+++ b/AsyncImageView/Renderers/ImageInflaterRenderer.swift
@@ -73,7 +73,7 @@ public final class ImageInflaterRenderer<Renderer: RendererType>: RendererType {
 	}
 }
 
-public enum ImageInflaterRendererContentMode {
+public enum ImageInflaterRendererContentMode: Sendable {
     case aspectFill
     case aspectFit
 

--- a/AsyncImageView/Renderers/Renderer.swift
+++ b/AsyncImageView/Renderers/Renderer.swift
@@ -11,7 +11,7 @@ import UIKit
 import ReactiveSwift
 
 /// Information required to produce an image
-public protocol RenderDataType: Hashable {
+public protocol RenderDataType: Hashable, Sendable {
 	var size: CGSize { get }
 }
 

--- a/AsyncImageView/Renderers/ViewRenderer.swift
+++ b/AsyncImageView/Renderers/ViewRenderer.swift
@@ -15,8 +15,9 @@ import ReactiveSwift
 
 /// `RendererType` which generates a `UIImage` from a UIView.
 @available(iOS 10.0, tvOSApplicationExtension 10.0, *)
-public final class ViewRenderer<Data: RenderDataType>: RendererType {
-    public typealias Block = (_ data: Data) -> UIView
+@MainActor
+public final class ViewRenderer<Data: RenderDataType>: @MainActor RendererType {
+    public typealias Block = @MainActor (_ data: Data) -> UIView
 
     private let format: UIGraphicsImageRendererFormat
     private let viewCreationBlock: Block
@@ -49,8 +50,9 @@ public final class ViewRenderer<Data: RenderDataType>: RendererType {
 }
 
 /// `RendererType` which generates a `UIImage` from a UIView.
-public final class OldViewRenderer<Data: RenderDataType>: RendererType {
-    public typealias Block = (_ data: Data) -> UIView
+@MainActor
+public final class OldViewRenderer<Data: RenderDataType>: @MainActor RendererType {
+    public typealias Block = @MainActor (_ data: Data) -> UIView
 
     private let opaque: Bool
     private let viewCreationBlock: Block
@@ -82,27 +84,32 @@ public final class OldViewRenderer<Data: RenderDataType>: RendererType {
 
 fileprivate func createProducer<Data: RenderDataType>(
     _ data: Data,
-    viewCreationBlock: @escaping (_ data: Data) -> UIView,
-    renderBlock: @escaping (UIView) -> UIImage
+    viewCreationBlock: @escaping @MainActor (_ data: Data) -> UIView,
+    renderBlock: @escaping @MainActor (UIView) -> UIImage
 ) -> SignalProducer<UIImage, Never> {
     return SignalProducer { observer, lifetime in
-        let view = viewCreationBlock(data)
-        view.frame.origin = .zero
-        view.bounds.size = data.size
-        view.layoutIfNeeded()
+        MainActor.assumeIsolated {
+            let view = viewCreationBlock(data)
+            view.frame.origin = .zero
+            view.bounds.size = data.size
+            view.layoutIfNeeded()
 
-        // Make the CA renderer wait "until all the post-commit triggers fire".
-        // We can't take a snapshot right away because the view has not been commited to the render server yet.
-        DispatchQueue.main.async {
-            if !lifetime.hasEnded {
-                observer.send(value: renderBlock(view))
-                observer.sendCompleted()
+            // Make the CA renderer wait "until all the post-commit triggers fire".
+            // We can't take a snapshot right away because the view has not been commited to the render server yet.
+            UIScheduler().schedule {
+                MainActor.assumeIsolated {
+                    if !lifetime.hasEnded {
+                        observer.send(value: renderBlock(view))
+                        observer.sendCompleted()
+                    }
+                }
             }
         }
     }
         .start(on: UIScheduler())
 }
 
+@MainActor
 fileprivate func draw(view: UIView, inContext context: CGContext) {
     view.layer.render(in: context)
 }

--- a/AsyncImageView/SynchronousUIScheduler.swift
+++ b/AsyncImageView/SynchronousUIScheduler.swift
@@ -22,7 +22,7 @@ internal final class SynchronousUIScheduler: Scheduler {
         if Thread.isMainThread {
             action()
         } else {
-            DispatchQueue.main.async {
+            UIScheduler().schedule {
                 if !disposable.isDisposed {
                     action()
                 }


### PR DESCRIPTION
## Scope

Part 2 of 4 in the Swift 6 migration. This PR contains production correctness changes only:

- make render data and image-inflater content mode `Sendable`
- isolate UIKit view rendering and view-construction callbacks to the main actor
- route deferred UI work through `UIScheduler`

## Dependencies

- Base: [#84 — package configuration](https://github.com/NachoSoto/AsyncImageView/pull/84)
- Follow-up: the next PR adds the narrowly scoped escape hatches required for non-Sendable ReactiveSwift callback state.

This branch intentionally depends on its follow-up for a complete Swift 6 build; review it for the actor-boundary design.

## Validation

- `swiftlint --config .swiftlint.yml --strict`
- `git diff --check`