### PR TITLE
[Concurrency] Constrain Swift 6 escape hatches

### DIFF
--- a/AsyncImageView/AsyncImageView.swift
+++ b/AsyncImageView/AsyncImageView.swift
@@ -39,7 +39,7 @@ open class AsyncImageView<
 
 	private let imageCreationScheduler: ReactiveSwift.Scheduler
 
-	private var disposable: Disposable?
+	nonisolated(unsafe) private var disposable: Disposable?
 
 	public init(
 		initialFrame: CGRect,

--- a/AsyncImageView/Renderers/ViewRenderer.swift
+++ b/AsyncImageView/Renderers/ViewRenderer.swift
@@ -88,6 +88,9 @@ fileprivate func createProducer<Data: RenderDataType>(
     renderBlock: @escaping @MainActor (UIView) -> UIImage
 ) -> SignalProducer<UIImage, Never> {
     return SignalProducer { observer, lifetime in
+        let observer = UncheckedSendableBox(value: observer)
+        let lifetime = UncheckedSendableBox(value: lifetime)
+
         MainActor.assumeIsolated {
             let view = viewCreationBlock(data)
             view.frame.origin = .zero
@@ -98,9 +101,9 @@ fileprivate func createProducer<Data: RenderDataType>(
             // We can't take a snapshot right away because the view has not been commited to the render server yet.
             UIScheduler().schedule {
                 MainActor.assumeIsolated {
-                    if !lifetime.hasEnded {
-                        observer.send(value: renderBlock(view))
-                        observer.sendCompleted()
+                    if !lifetime.value.hasEnded {
+                        observer.value.send(value: renderBlock(view))
+                        observer.value.sendCompleted()
                     }
                 }
             }
@@ -112,6 +115,10 @@ fileprivate func createProducer<Data: RenderDataType>(
 @MainActor
 fileprivate func draw(view: UIView, inContext context: CGContext) {
     view.layer.render(in: context)
+}
+
+fileprivate struct UncheckedSendableBox<Value>: @unchecked Sendable {
+    let value: Value
 }
 
 #endif


### PR DESCRIPTION
## Scope

Part 3 of 4 in the Swift 6 migration. This PR contains only the explicit production escape hatches needed around legacy ReactiveSwift state:

- mark the disposable accessed from UIKit deinitialization as `nonisolated(unsafe)`
- wrap the non-Sendable ReactiveSwift observer and lifetime in a tightly scoped `@unchecked Sendable` box before the main-actor callback

## Dependencies

- Base: [#85 — production concurrency boundaries](https://github.com/NachoSoto/AsyncImageView/pull/85)
- Follow-up: test-only Swift 6 migrations and cleanup will base on this PR.

The unsafe annotations are intentionally isolated here so reviewers can audit their scope independently from the actor-boundary changes.

## Validation

- iOS Simulator library build succeeds
- `swiftlint --config .swiftlint.yml --strict`
- `git diff --check`