### PR TITLE
[Build] Validate Swift 6 library compilation

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Select Xcode
         uses: mxcl/xcodebuild@v3
         with:
-          xcode: '26.5'
+          xcode: '26.6'
           action: none
 
       - name: Build library in Swift 6 mode

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,6 +8,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  swift-6-build:
+    runs-on: macos-26
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        uses: mxcl/xcodebuild@v3
+        with:
+          xcode: '26.5'
+          action: none
+
+      - name: Build library in Swift 6 mode
+        run: |
+          swift build \
+            --target AsyncImageView \
+            --triple arm64-apple-ios18.0-simulator \
+            --sdk "$(xcrun --sdk iphonesimulator --show-sdk-path)"
+
   test:
     runs-on: macos-26
     timeout-minutes: 30

--- a/AsyncImageView/AsyncImageView.swift
+++ b/AsyncImageView/AsyncImageView.swift
@@ -9,7 +9,7 @@
 import UIKit
 import Combine
 
-import ReactiveSwift
+@preconcurrency import ReactiveSwift
 
 public protocol ImageViewDataType {
 	associatedtype RenderData: RenderDataType
@@ -39,7 +39,7 @@ open class AsyncImageView<
 
 	private let imageCreationScheduler: ReactiveSwift.Scheduler
 
-	nonisolated(unsafe) private var disposable: Disposable?
+	private var disposable: Disposable?
 
 	public init(
 		initialFrame: CGRect,

--- a/AsyncImageView/AsyncImageView.swift
+++ b/AsyncImageView/AsyncImageView.swift
@@ -39,7 +39,7 @@ open class AsyncImageView<
 
 	private let imageCreationScheduler: ReactiveSwift.Scheduler
 
-	private var disposable: Disposable?
+	nonisolated(unsafe) private var disposable: Disposable?
 
 	public init(
 		initialFrame: CGRect,

--- a/AsyncImageView/Renderers/ImageInflaterRenderer.swift
+++ b/AsyncImageView/Renderers/ImageInflaterRenderer.swift
@@ -73,7 +73,7 @@ public final class ImageInflaterRenderer<Renderer: RendererType>: RendererType {
 	}
 }
 
-public enum ImageInflaterRendererContentMode {
+public enum ImageInflaterRendererContentMode: Sendable {
     case aspectFill
     case aspectFit
 

--- a/AsyncImageView/Renderers/Renderer.swift
+++ b/AsyncImageView/Renderers/Renderer.swift
@@ -11,7 +11,7 @@ import UIKit
 import ReactiveSwift
 
 /// Information required to produce an image
-public protocol RenderDataType: Hashable {
+public protocol RenderDataType: Hashable, Sendable {
 	var size: CGSize { get }
 }
 

--- a/AsyncImageView/Renderers/ViewRenderer.swift
+++ b/AsyncImageView/Renderers/ViewRenderer.swift
@@ -15,8 +15,9 @@ import ReactiveSwift
 
 /// `RendererType` which generates a `UIImage` from a UIView.
 @available(iOS 10.0, tvOSApplicationExtension 10.0, *)
-public final class ViewRenderer<Data: RenderDataType>: RendererType {
-    public typealias Block = (_ data: Data) -> UIView
+@MainActor
+public final class ViewRenderer<Data: RenderDataType>: @MainActor RendererType {
+    public typealias Block = @MainActor (_ data: Data) -> UIView
 
     private let format: UIGraphicsImageRendererFormat
     private let viewCreationBlock: Block
@@ -49,8 +50,9 @@ public final class ViewRenderer<Data: RenderDataType>: RendererType {
 }
 
 /// `RendererType` which generates a `UIImage` from a UIView.
-public final class OldViewRenderer<Data: RenderDataType>: RendererType {
-    public typealias Block = (_ data: Data) -> UIView
+@MainActor
+public final class OldViewRenderer<Data: RenderDataType>: @MainActor RendererType {
+    public typealias Block = @MainActor (_ data: Data) -> UIView
 
     private let opaque: Bool
     private let viewCreationBlock: Block
@@ -82,29 +84,41 @@ public final class OldViewRenderer<Data: RenderDataType>: RendererType {
 
 fileprivate func createProducer<Data: RenderDataType>(
     _ data: Data,
-    viewCreationBlock: @escaping (_ data: Data) -> UIView,
-    renderBlock: @escaping (UIView) -> UIImage
+    viewCreationBlock: @escaping @MainActor (_ data: Data) -> UIView,
+    renderBlock: @escaping @MainActor (UIView) -> UIImage
 ) -> SignalProducer<UIImage, Never> {
     return SignalProducer { observer, lifetime in
-        let view = viewCreationBlock(data)
-        view.frame.origin = .zero
-        view.bounds.size = data.size
-        view.layoutIfNeeded()
+        let observer = UncheckedSendableBox(value: observer)
+        let lifetime = UncheckedSendableBox(value: lifetime)
 
-        // Make the CA renderer wait "until all the post-commit triggers fire".
-        // We can't take a snapshot right away because the view has not been commited to the render server yet.
-        DispatchQueue.main.async {
-            if !lifetime.hasEnded {
-                observer.send(value: renderBlock(view))
-                observer.sendCompleted()
+        MainActor.assumeIsolated {
+            let view = viewCreationBlock(data)
+            view.frame.origin = .zero
+            view.bounds.size = data.size
+            view.layoutIfNeeded()
+
+            // Make the CA renderer wait "until all the post-commit triggers fire".
+            // We can't take a snapshot right away because the view has not been commited to the render server yet.
+            UIScheduler().schedule {
+                MainActor.assumeIsolated {
+                    if !lifetime.value.hasEnded {
+                        observer.value.send(value: renderBlock(view))
+                        observer.value.sendCompleted()
+                    }
+                }
             }
         }
     }
         .start(on: UIScheduler())
 }
 
+@MainActor
 fileprivate func draw(view: UIView, inContext context: CGContext) {
     view.layer.render(in: context)
+}
+
+fileprivate struct UncheckedSendableBox<Value>: @unchecked Sendable {
+    let value: Value
 }
 
 #endif

--- a/AsyncImageView/Renderers/ViewRenderer.swift
+++ b/AsyncImageView/Renderers/ViewRenderer.swift
@@ -9,7 +9,7 @@
 import UIKit
 import CoreGraphics
 
-import ReactiveSwift
+@preconcurrency import ReactiveSwift
 
 #if !os(watchOS)
 
@@ -88,9 +88,6 @@ fileprivate func createProducer<Data: RenderDataType>(
     renderBlock: @escaping @MainActor (UIView) -> UIImage
 ) -> SignalProducer<UIImage, Never> {
     return SignalProducer { observer, lifetime in
-        let observer = UncheckedSendableBox(value: observer)
-        let lifetime = UncheckedSendableBox(value: lifetime)
-
         MainActor.assumeIsolated {
             let view = viewCreationBlock(data)
             view.frame.origin = .zero
@@ -101,9 +98,9 @@ fileprivate func createProducer<Data: RenderDataType>(
             // We can't take a snapshot right away because the view has not been commited to the render server yet.
             UIScheduler().schedule {
                 MainActor.assumeIsolated {
-                    if !lifetime.value.hasEnded {
-                        observer.value.send(value: renderBlock(view))
-                        observer.value.sendCompleted()
+                    if !lifetime.hasEnded {
+                        observer.send(value: renderBlock(view))
+                        observer.sendCompleted()
                     }
                 }
             }
@@ -115,10 +112,6 @@ fileprivate func createProducer<Data: RenderDataType>(
 @MainActor
 fileprivate func draw(view: UIView, inContext context: CGContext) {
     view.layer.render(in: context)
-}
-
-fileprivate struct UncheckedSendableBox<Value>: @unchecked Sendable {
-    let value: Value
 }
 
 #endif

--- a/AsyncImageView/SynchronousUIScheduler.swift
+++ b/AsyncImageView/SynchronousUIScheduler.swift
@@ -22,7 +22,7 @@ internal final class SynchronousUIScheduler: Scheduler {
         if Thread.isMainThread {
             action()
         } else {
-            DispatchQueue.main.async {
+            UIScheduler().schedule {
                 if !disposable.isDisposed {
                     action()
                 }

--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,7 @@ let package = Package(
             dependencies: ["ReactiveSwift"],
             path: "AsyncImageView",
             swiftSettings: [
+                // Work around https://github.com/swiftlang/swift/issues/75453.
                 .unsafeFlags(["-disable-dynamic-actor-isolation"])
             ]
         ),
@@ -31,6 +32,7 @@ let package = Package(
             ],
             path: "AsyncImageViewTests",
             swiftSettings: [
+                // Work around https://github.com/swiftlang/swift/issues/75453.
                 .unsafeFlags(["-disable-dynamic-actor-isolation"])
             ]
         )

--- a/Package.swift
+++ b/Package.swift
@@ -19,15 +19,21 @@ let package = Package(
         .target(
             name: "AsyncImageView",
             dependencies: ["ReactiveSwift"],
-            path: "AsyncImageView"
+            path: "AsyncImageView",
+            swiftSettings: [
+                .unsafeFlags(["-disable-dynamic-actor-isolation"])
+            ]
         ),
         .testTarget(
             name: "AsyncImageViewTests",
             dependencies: [
                 "AsyncImageView"
             ],
-            path: "AsyncImageViewTests"
+            path: "AsyncImageViewTests",
+            swiftSettings: [
+                .unsafeFlags(["-disable-dynamic-actor-isolation"])
+            ]
         )
     ],
-    swiftLanguageVersions: [.v5]
+    swiftLanguageModes: [.v6]
 )


### PR DESCRIPTION
## Summary

- rebase this PR directly onto `master` after the Swift Testing migration landed
- configure AsyncImageView package targets for Swift 6 with `-disable-dynamic-actor-isolation`
- document the flag as a workaround for swiftlang/swift#75453
- add an Xcode 26.6 SwiftPM iOS-simulator library build to CI
- make render data and image content modes `Sendable`
- isolate UIKit rendering to the main actor and preserve scheduler behavior
- use `@preconcurrency` for the Swift 5 ReactiveSwift boundary, avoiding `nonisolated(unsafe)` storage and unchecked boxes

## CI reproduction

Commit `82dfc96` contains the Swift 6 configuration and CI gate before the production fix. [Build and Test run 30112895900](https://github.com/NachoSoto/AsyncImageView/actions/runs/30112895900) fails in both jobs with the same downstream diagnostic:

> static property 'defaultMode' is not concurrency-safe because non-'Sendable' type 'ImageInflaterRendererContentMode' may have shared mutable state

Commit `b7769e4` fixes that failure and the subsequent renderer, scheduler, and deinitializer concurrency errors in this same PR. Commit `e0636d5` incorporates review feedback by replacing the explicit ReactiveSwift escape hatches with `@preconcurrency` imports.

## Validation

- [Build and Test run 30113461493](https://github.com/NachoSoto/AsyncImageView/actions/runs/30113461493): Swift 6 compatibility build, iOS Simulator test suite, and SwiftLint passed
- local SwiftPM iOS-simulator library build in Swift 6 mode with dynamic actor isolation disabled
- local full iOS Simulator test suite
- `swiftlint --config .swiftlint.yml --strict`
- `git diff --check`

## Dependencies

None. The previous test-only commit was superseded by merged PR #88, so this PR is now based directly on `master`.